### PR TITLE
Benchmark harness: error taxonomy & burst (swarm), AWS DistributedComponents, tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ results/runs/
 scripts/cloud/.benchmark-aws-state*.json
 scripts/cloud/aws_runs_*/
 results/last-ssm-invoke.json
+
+# Pester / test output
+testResults.xml

--- a/README.md
+++ b/README.md
@@ -19,6 +19,17 @@
 
 **Pass:** client error rate **&lt; 1%**, average latency **&lt; 200 ms**. **Ceiling:** highest player count that passes.
 
+Error rate is computed from explicit categories emitted by `arcane-swarm` in `FINAL` lines:
+- `timeout`: request timed out before completion.
+- `not_delivered`: write/connect failed before payload delivery.
+- `http_status`: backend returned non-2xx.
+- `transport`: non-timeout network/IO failure.
+- `connection_drop`: established stream closed unexpectedly.
+
+Deterministic burst mode is enabled by default for worst-case reproducible runs:
+- periodic action burst: every `--burst-period-secs`, a deterministic cohort (`--burst-cohort-percent`) emits `--burst-actions-per-player` actions inside `--burst-window-ms`.
+- periodic zone event: every `--zone-event-period-secs`, all players steer toward map center for `--zone-event-window-ms`.
+
 ---
 
 ## Reference run — AWS (`SingleInstance`)
@@ -46,6 +57,33 @@ $env:ARCANE_BENCHMARK_GITHUB_TOKEN = (gh auth token).Trim()
 .\Run-Benchmark-Aws.ps1 -ArtifactBucket <bucket> -IamInstanceProfileName <profile> -Region us-east-1 -TerminateOnExit
 ```
 
+For **Redis and SpacetimeDB on separate instances** (driver on a third machine, private VPC networking between them), use **`-Environment DistributedComponents`** and see [scripts/cloud/environments/DistributedComponents/README.md](scripts/cloud/environments/DistributedComponents/README.md).
+
+You can also drive local benchmark parameters from a JSON config file instead of passing many flags:
+
+```powershell
+.\scripts\Run-Benchmark.ps1 -ConfigFile .\benchmark.config.json
+```
+
+Example `benchmark.config.json`:
+
+```json
+{
+  "DurationSeconds": 30,
+  "FindArcaneCeiling": true,
+  "ArcaneClusterCounts": [1, 2, 3, 4, 5, 10],
+  "MaxErrRate": 0.01,
+  "MaxLatencyMs": 200,
+  "BurstEnabled": true,
+  "BurstPeriodSecs": 30,
+  "BurstCohortPercent": 20,
+  "BurstActionsPerPlayer": 10,
+  "BurstWindowMs": 500,
+  "ZoneEventPeriodSecs": 30,
+  "ZoneEventWindowMs": 500
+}
+```
+
 Pull artifacts for an existing run:
 
 ```powershell
@@ -53,3 +91,14 @@ Pull artifacts for an existing run:
 ```
 
 AWS options and IAM expectations: [scripts/cloud/README.md](scripts/cloud/README.md). Local parity run: [REPRODUCIBILITY.md](REPRODUCIBILITY.md). Full parameter list: [docs/CANONICAL_PARAMETERS.md](docs/CANONICAL_PARAMETERS.md).
+
+## Tests (PowerShell)
+
+CI runs **Pester** on `tests/*.Tests.ps1` (Windows). Locally:
+
+```powershell
+Install-Module Pester -Scope CurrentUser -Force -SkipPublisherCheck
+Invoke-Pester -Path ./tests -CI
+```
+
+These are **unit / layout** checks (no AWS, Redis, or Spacetime required).

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -41,6 +41,10 @@ $env:SPACETIME_IMAGE = 'clockworklabs/spacetime:2.0.5'
 
 Stop/remove containers when finished: `docker rm -f arcane-bench-redis arcane-bench-spacetime`
 
+### Networking and published ceilings
+
+Docker on **Windows** or **macOS** does not support a portable, in-repo way to inject realistic **inter-machine** RTT the way Linux-only `tc`/`netem` on the host would. The harness is aimed at **PowerShell 7 + Docker Desktop** for local runs. Treat **local ceilings** as workload-valid but **network-optimistic** relative to multi-node production. For numbers you publish as “real WAN-ish,” plan **multi-host or cloud** runs where latency comes from the actual topology (documented in the run manifest and README when you update them).
+
 ```powershell
 git clone --recurse-submodules https://github.com/brainy-bots/arcane-scaling-benchmarks.git
 cd arcane-scaling-benchmarks
@@ -112,4 +116,4 @@ Compare ceiling lines from the script output or CSVs with **arcane-demos** `docs
 
 ## AWS
 
-Optional flow: **`scripts/cloud/Run-Benchmark-Aws.ps1`** (provision → SSM bootstrap → `Run-Benchmark.ps1` → stage via S3 → **download to `results/runs/<Environment>/<runId>/` locally**; **`-TerminateOnExit`** to destroy the instance). **`Setup-AwsBenchmark.ps1`** / **`Cleanup-AwsBenchmark.ps1`** split provision and teardown; **`-Environment`** selects a topology under `scripts/cloud/environments/` (default `SingleInstance`). See **`scripts/cloud/README.md`** and **`scripts/cloud/environments/README.md`**.
+Optional flow: **`scripts/cloud/Run-Benchmark-Aws.ps1`** (provision → SSM bootstrap → `Run-Benchmark.ps1` → stage via S3 → **download to `results/runs/<Environment>/<runId>/` locally**; **`-TerminateOnExit`** to destroy the instance). **`Setup-AwsBenchmark.ps1`** / **`Cleanup-AwsBenchmark.ps1`** split provision and teardown; **`-Environment`** selects a topology under `scripts/cloud/environments/` — **`SingleInstance`** (one box) or **`DistributedComponents`** (Redis, SpacetimeDB, and driver on **three** instances with **private VPC** networking between them). See **`scripts/cloud/README.md`** and **`scripts/cloud/environments/DistributedComponents/README.md`**.

--- a/docs/CANONICAL_PARAMETERS.md
+++ b/docs/CANONICAL_PARAMETERS.md
@@ -15,6 +15,34 @@ These parameters are **fixed** across all ceiling/scaling experiments so that Sp
 | **spacetimedb_persist_hz** | 1 | (Arcane+Spacetime) Batch persist to SpacetimeDB per second |
 | **spacetimedb_persist_batch_size** | 0 recommended | 0 = one request per persist window; 500 = cap (worse ceilings in our runs) |
 | **redis_enabled** | true | (Arcane+Spacetime) Replication when num_servers > 1 |
+| **burst_enabled** | true (default) | Deterministic worst-case burst profile is part of baseline |
 | **pass_criteria** | err_rate < 1%, lat_avg_ms < 200 | Pass/fail per run |
 
 Effective values for each run are also recorded in **`results/runs/<Environment>/<timestamp>/benchmark_run_manifest.json`** (see `results/README.md`) so CSV ceilings can be compared with exact thresholds and workload settings.
+
+`scripts/Run-Benchmark.ps1` supports `-ConfigFile <path-to-json>` for setting these parameters from one file.
+
+## Error taxonomy used by `err_rate`
+
+`err_rate` uses `total_errs / total_calls`, where `total_errs` is the sum of these categories:
+- `timeout`
+- `not_delivered`
+- `http_status`
+- `transport`
+- `connection_drop`
+
+`arcane-swarm` emits these per-category counts as `err_json=...` in each `FINAL:` line so benchmark artifacts preserve the exact error mix, not only a single aggregate number.
+
+## Deterministic burst profile (default)
+
+When enabled, the profile is fully deterministic and reproducible:
+- `burst_period_secs` (default 30)
+- `burst_cohort_percent` (default 20)
+- `burst_actions_per_player` (default 10)
+- `burst_window_ms` (default 500)
+- `zone_event_period_secs` (default 30)
+- `zone_event_window_ms` (default 500)
+
+## Inter-node latency and published numbers
+
+There is **no** in-repo, cross-platform Docker recipe for artificial WAN-like delay that works for the typical **Windows + Docker Desktop** developer machine. Local runs remain valid for **workload and correctness** of the harness; **published** ceilings that must reflect **real multi-host RTT** should come from **cloud or multi-machine** runs (topology described in the run manifest and README).

--- a/results/README.md
+++ b/results/README.md
@@ -26,4 +26,4 @@ results/runs/<Environment>/<yyyyMMdd_HHmmss>/
 ## Overrides
 
 - Pass **`-OutDir`** to `Run-Benchmark.ps1` to use a different root (the same `spacetimedb_only/` and `arcane_plus_spacetimedb/` children are still created). **`Environment` is ignored** when `-OutDir` is set.
-- **AWS:** same path inside the cloned repo on EC2 (`results/runs/SingleInstance/<runId>/`), synced to **`s3://<bucket>/<prefix>/SingleInstance/<runId>/`**.
+- **AWS:** same path inside the cloned repo on EC2 (`results/runs/<Environment>/<runId>/`), synced to **`s3://<bucket>/<prefix>/<Environment>/<runId>/`** (e.g. **`SingleInstance`** or **`DistributedComponents`** — match **`-Environment`** when using `Sync-AwsBenchmarkResultsFromS3.ps1`).

--- a/scripts/BenchmarkHarnessHelpers.ps1
+++ b/scripts/BenchmarkHarnessHelpers.ps1
@@ -1,0 +1,67 @@
+# Shared helpers for Run-Benchmark.ps1 (dot-source from that script so Merge-ConfigFileParameters
+# can Set-Variable -Scope Script into the caller's script scope).
+
+function Get-SafeResultsEnvironmentSegment([string]$name) {
+  if ([string]::IsNullOrWhiteSpace($name)) { return 'Local' }
+  $s = $name.Trim() -replace '[<>:"/\\|?*]', '_'
+  if ([string]::IsNullOrWhiteSpace($s)) { return 'Local' }
+  return $s
+}
+
+function Merge-ConfigFileParameters {
+  param([string]$Path)
+
+  if ([string]::IsNullOrWhiteSpace($Path)) { return }
+  if (-not (Test-Path -LiteralPath $Path)) {
+    throw "Config file not found: $Path"
+  }
+
+  $raw = Get-Content -LiteralPath $Path -Raw -ErrorAction Stop
+  $cfg = $raw | ConvertFrom-Json -ErrorAction Stop
+  if ($null -eq $cfg) { return }
+
+  $supported = @(
+    'SpacetimeStep',
+    'SpacetimeMaxPlayers',
+    'DurationSeconds',
+    'FindArcaneCeiling',
+    'ArcaneClusterCounts',
+    'ArcaneCeilingStartPlayers',
+    'ArcaneCeilingStep',
+    'ArcaneCeilingMaxPlayers',
+    'PersistBatchSize',
+    'MaxErrRate',
+    'MaxLatencyMs',
+    'SpacetimeHost',
+    'DatabaseName',
+    'RedisHost',
+    'RedisPort',
+    'TickRateHz',
+    'ActionsPerSec',
+    'ReadRateHz',
+    'SwarmMode',
+    'BurstEnabled',
+    'BurstPeriodSecs',
+    'BurstCohortPercent',
+    'BurstActionsPerPlayer',
+    'BurstWindowMs',
+    'ZoneEventPeriodSecs',
+    'ZoneEventWindowMs',
+    'BetweenIncrementsSeconds',
+    'SpacetimePersistHz',
+    'Environment',
+    'OutDir',
+    'SwarmExe',
+    'ArcaneManagerExe',
+    'ArcaneClusterExe'
+  )
+  $supportedSet = @{}
+  foreach ($k in $supported) { $supportedSet[$k] = $true }
+
+  foreach ($prop in $cfg.PSObject.Properties) {
+    if (-not $supportedSet.ContainsKey($prop.Name)) {
+      throw "Unsupported config key '$($prop.Name)' in $Path"
+    }
+    Set-Variable -Name $prop.Name -Value $prop.Value -Scope Script
+  }
+}

--- a/scripts/Run-Benchmark.ps1
+++ b/scripts/Run-Benchmark.ps1
@@ -23,6 +23,7 @@
 #>
 
 param(
+  [string] $ConfigFile = '',
   [int] $SpacetimeStep = 250,
   [int] $SpacetimeMaxPlayers = 2000,
   [int] $DurationSeconds = 30,
@@ -48,6 +49,14 @@ param(
   [double] $ActionsPerSec = 2,
   [double] $ReadRateHz = 5,
   [string] $SwarmMode = 'spread',
+  [switch] $BurstEnabled = $true,
+  [int] $BurstPeriodSecs = 30,
+  [int] $BurstCohortPercent = 20,
+  [int] $BurstActionsPerPlayer = 10,
+  [int] $BurstWindowMs = 500,
+  [int] $ZoneEventPeriodSecs = 30,
+  [int] $ZoneEventWindowMs = 500,
+
   [int] $BetweenIncrementsSeconds = 1,
   [int] $SpacetimePersistHz = 1,
 
@@ -60,6 +69,10 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+. (Join-Path $PSScriptRoot 'BenchmarkHarnessHelpers.ps1')
+
+Merge-ConfigFileParameters -Path $ConfigFile
+
 # Best-effort: text of the command line as PowerShell saw it (often empty with -File from some hosts).
 $BenchmarkHostInvocationLine = $null
 if ($MyInvocation.Line -and $MyInvocation.Line.Trim()) {
@@ -68,13 +81,6 @@ if ($MyInvocation.Line -and $MyInvocation.Line.Trim()) {
 
 $ScriptDir = $PSScriptRoot
 $BenchmarkRoot = Resolve-Path (Join-Path $ScriptDir '..')
-
-function Get-SafeResultsEnvironmentSegment([string]$name) {
-  if ([string]::IsNullOrWhiteSpace($name)) { return 'Local' }
-  $s = $name.Trim() -replace '[<>:"/\\|?*]', '_'
-  if ([string]::IsNullOrWhiteSpace($s)) { return 'Local' }
-  return $s
-}
 
 function Get-ExeSuffix {
   if ($PSVersionTable.PSVersion.Major -ge 6) {
@@ -259,6 +265,10 @@ function Build-BenchmarkReproCommandLine {
   $null = $parts.Add('-NoProfile')
   $null = $parts.Add('-File')
   $null = $parts.Add((Escape-SingleQuotedPwsh $PSCommandPath))
+  if (-not [string]::IsNullOrWhiteSpace($ConfigFile)) {
+    $null = $parts.Add('-ConfigFile')
+    $null = $parts.Add((Escape-SingleQuotedPwsh $ConfigFile))
+  }
 
   $ap = {
     param([string]$Name, $Value)
@@ -305,6 +315,13 @@ function Build-BenchmarkReproCommandLine {
   & $ap 'ActionsPerSec' $ActionsPerSec
   & $ap 'ReadRateHz' $ReadRateHz
   & $ap 'SwarmMode' $SwarmMode
+  $null = $parts.Add($(if ($BurstEnabled) { '-BurstEnabled' } else { '-BurstEnabled:$false' }))
+  & $ap 'BurstPeriodSecs' $BurstPeriodSecs
+  & $ap 'BurstCohortPercent' $BurstCohortPercent
+  & $ap 'BurstActionsPerPlayer' $BurstActionsPerPlayer
+  & $ap 'BurstWindowMs' $BurstWindowMs
+  & $ap 'ZoneEventPeriodSecs' $ZoneEventPeriodSecs
+  & $ap 'ZoneEventWindowMs' $ZoneEventWindowMs
   & $ap 'BetweenIncrementsSeconds' $BetweenIncrementsSeconds
   & $ap 'SpacetimePersistHz' $SpacetimePersistHz
   & $ap 'Environment' $Environment
@@ -368,6 +385,7 @@ function Export-BenchmarkRunManifest {
     invocation       = @{
       script_path                  = $PSCommandPath
       host_powershell_line         = $BenchmarkHostInvocationLine
+      config_file                  = $(if ([string]::IsNullOrWhiteSpace($ConfigFile)) { $null } else { (Resolve-Path -LiteralPath $ConfigFile).Path })
       repro_command_pwsh_no_profile = (Build-BenchmarkReproCommandLine)
     }
     environment_label = (Get-SafeResultsEnvironmentSegment $Environment)
@@ -391,6 +409,15 @@ function Export-BenchmarkRunManifest {
         read_rate_cli_flag  = '--read-rate'
         movement_mode       = $SwarmMode
         mode_cli_flag       = '--mode'
+        burst_profile       = @{
+          enabled = [bool]$BurstEnabled
+          burst_period_secs = $BurstPeriodSecs
+          burst_cohort_percent = $BurstCohortPercent
+          burst_actions_per_player = $BurstActionsPerPlayer
+          burst_window_ms = $BurstWindowMs
+          zone_event_period_secs = $ZoneEventPeriodSecs
+          zone_event_window_ms = $ZoneEventWindowMs
+        }
       }
       process_flags     = @{
         duration_seconds_cli = 0
@@ -454,7 +481,7 @@ function Send-SwarmCommand([int]$Port, [string]$Line) {
 }
 
 function Parse-SwarmFinal([string] $Text) {
-  $re = 'FINAL:\s*players=(\d+)\s+total_calls=(\d+)\s+total_oks=(\d+)\s+total_errs=(\d+)\s+lat_avg_ms=([\d.]+)'
+  $re = 'FINAL:\s*players=(\d+)\s+total_calls=(\d+)\s+total_oks=(\d+)\s+total_errs=(\d+)\s+lat_avg_ms=([\d.]+)(?:\s+err_json=(\{.*?\}))?'
   $all = [regex]::Matches($Text, $re)
   if ($all.Count -eq 0) { return $null }
 
@@ -465,6 +492,7 @@ function Parse-SwarmFinal([string] $Text) {
     total_oks    = [long]$m.Groups[3].Value
     total_errs   = [long]$m.Groups[4].Value
     lat_avg_ms   = [double]$m.Groups[5].Value
+    err_json     = $m.Groups[6].Value
   }
 }
 
@@ -491,10 +519,7 @@ function Run-Scenario-SpacetimeOnly {
   Write-Host "SpacetimeDB-only scenario (control port $ControlPort)" -ForegroundColor Cyan
   Stop-ListenerOnPort -Port $ControlPort
 
-  $proc = Start-Process -FilePath $SwarmExe -WorkingDirectory $SwarmWorkspaceRoot -NoNewWindow -PassThru `
-    -RedirectStandardOutput (Join-Path $stdErrDir "spacetimedb_only_${ControlPort}_stdout.log") `
-    -RedirectStandardError $stderr `
-    -ArgumentList @(
+  $swarmArgs = @(
     '--backend', 'spacetimedb',
     '--server-physics',
     '--players', $ScenarioStartPlayers,
@@ -509,6 +534,23 @@ function Run-Scenario-SpacetimeOnly {
     '--uri', $SpacetimeHost,
     '--db', $DatabaseName
   )
+  if ($BurstEnabled) {
+    $swarmArgs += @(
+      '--burst-enabled',
+      '--burst-period-secs', $BurstPeriodSecs,
+      '--burst-cohort-percent', $BurstCohortPercent,
+      '--burst-actions-per-player', $BurstActionsPerPlayer,
+      '--burst-window-ms', $BurstWindowMs,
+      '--zone-event-period-secs', $ZoneEventPeriodSecs,
+      '--zone-event-window-ms', $ZoneEventWindowMs
+    )
+  } else {
+    $swarmArgs += @('--burst-disabled')
+  }
+  $proc = Start-Process -FilePath $SwarmExe -WorkingDirectory $SwarmWorkspaceRoot -NoNewWindow -PassThru `
+    -RedirectStandardOutput (Join-Path $stdErrDir "spacetimedb_only_${ControlPort}_stdout.log") `
+    -RedirectStandardError $stderr `
+    -ArgumentList $swarmArgs
 
   if (-not (Wait-TcpOpen -TcpHost '127.0.0.1' -Port $ControlPort -TimeoutSeconds 20)) {
     throw "swarm control port $ControlPort was not opened (spacetime-only scenario)"
@@ -629,10 +671,7 @@ function Run-Scenario-Arcane {
   if (Test-Path $stderr) { Remove-Item $stderr -Force }
   if (Test-Path $stdout) { Remove-Item $stdout -Force }
 
-  $procSwarm = Start-Process -FilePath $SwarmExe -WorkingDirectory $SwarmWorkspaceRoot -NoNewWindow -PassThru `
-    -RedirectStandardOutput $stdout `
-    -RedirectStandardError $stderr `
-    -ArgumentList @(
+  $swarmArgs = @(
     '--backend', 'arcane',
     '--players', $ScenarioStartPlayers,
     '--max-players', $ScenarioMaxPlayers,
@@ -647,6 +686,23 @@ function Run-Scenario-Arcane {
     '--uri', $SpacetimeHost,
     '--db', $DatabaseName
   )
+  if ($BurstEnabled) {
+    $swarmArgs += @(
+      '--burst-enabled',
+      '--burst-period-secs', $BurstPeriodSecs,
+      '--burst-cohort-percent', $BurstCohortPercent,
+      '--burst-actions-per-player', $BurstActionsPerPlayer,
+      '--burst-window-ms', $BurstWindowMs,
+      '--zone-event-period-secs', $ZoneEventPeriodSecs,
+      '--zone-event-window-ms', $ZoneEventWindowMs
+    )
+  } else {
+    $swarmArgs += @('--burst-disabled')
+  }
+  $procSwarm = Start-Process -FilePath $SwarmExe -WorkingDirectory $SwarmWorkspaceRoot -NoNewWindow -PassThru `
+    -RedirectStandardOutput $stdout `
+    -RedirectStandardError $stderr `
+    -ArgumentList $swarmArgs
 
   if (-not (Wait-TcpOpen -TcpHost '127.0.0.1' -Port $ControlPort -TimeoutSeconds 20)) {
     throw "swarm control port $ControlPort was not opened"

--- a/scripts/cloud/Cleanup-AwsBenchmark.ps1
+++ b/scripts/cloud/Cleanup-AwsBenchmark.ps1
@@ -3,8 +3,14 @@
   Tear down AWS benchmark infrastructure (from saved state or explicit IDs).
 
 .DESCRIPTION
-  Prefer -StatePath from Setup-AwsBenchmark.ps1 or a Run-Benchmark-Aws.ps1 run that saved state.
-  Alternatively pass -InstanceId and -Region (and security group fields if a temporary SG was created).
+  **Preferred:** pass **-StatePath** to the JSON written by Setup-AwsBenchmark.ps1 or by Run-Benchmark-Aws.ps1
+  (-StateOutPath). That file is the source of truth for instance IDs and the temporary security group.
+
+  **SingleInstance only:** you may omit -StatePath and pass **-Environment SingleInstance** with **-InstanceId**,
+  **-Region**, and optional **-SecurityGroupId** / **-CreatedSecurityGroup** when you created the SG in the same run.
+
+  **DistributedComponents:** **-StatePath is required.** This topology provisions three EC2 instances; manual
+  -InstanceId is not supported and would not tear down Redis/Spacetime/driver correctly.
 
 .PARAMETER SkipSecurityGroupDelete
   If set, do not delete a security group even when CreatedSecurityGroup is true.
@@ -60,6 +66,9 @@ if (-not (Test-Path -LiteralPath $cleanupPath)) { throw "Missing environment scr
 Assert-AwsCli
 
 if ($null -eq $state) {
+  if ($Environment -eq 'DistributedComponents') {
+    throw 'DistributedComponents requires -StatePath (JSON from setup or orchestrator). Manual -InstanceId is only valid for SingleInstance.'
+  }
   if ([string]::IsNullOrWhiteSpace($InstanceId) -or [string]::IsNullOrWhiteSpace($Region)) {
     throw 'Without -StatePath, you must pass -InstanceId and -Region.'
   }
@@ -72,17 +81,7 @@ if ($null -eq $state) {
   }
 }
 
-switch ($Environment) {
-  'SingleInstance' {
-    if ($SkipSecurityGroupDelete) {
-      Remove-SingleInstanceAwsBenchmarkEnvironment -State $state -SkipSecurityGroupDelete
-    } else {
-      Remove-SingleInstanceAwsBenchmarkEnvironment -State $state
-    }
-  }
-  default {
-    throw "Environment '$Environment' has no cleanup implementation in Cleanup-AwsBenchmark.ps1."
-  }
-}
+. (Join-Path $PSScriptRoot 'Common/AwsBenchmarkEnvironmentRegistry.ps1')
+Invoke-BenchmarkAwsEnvironmentRemove -Environment $Environment -State $state -SkipSecurityGroupDelete:$SkipSecurityGroupDelete
 
 Write-Host 'Cleanup finished.' -ForegroundColor Green

--- a/scripts/cloud/Common/AwsBenchmarkEnvironmentRegistry.ps1
+++ b/scripts/cloud/Common/AwsBenchmarkEnvironmentRegistry.ps1
@@ -1,0 +1,61 @@
+# Routes -Environment to environment-specific Initialize / RemoteBenchmark / Cleanup functions.
+# Dot-source after Common/AwsHelpers.ps1 and the environment module(s) needed for the current operation
+# (e.g. Setup.ps1 only for provision-only; Setup + RemoteBenchmark + Cleanup for full orchestration).
+
+function Invoke-BenchmarkAwsEnvironmentInitialize {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$Environment,
+    [Parameter(Mandatory)][hashtable]$Parameters
+  )
+  switch ($Environment) {
+    'SingleInstance' { return Initialize-SingleInstanceAwsBenchmarkEnvironment @Parameters }
+    'DistributedComponents' { return Initialize-DistributedComponentsAwsBenchmarkEnvironment @Parameters }
+    default {
+      throw "Environment '$Environment' has no Initialize implementation. Register it in AwsBenchmarkEnvironmentRegistry.ps1."
+    }
+  }
+}
+
+function Invoke-BenchmarkAwsEnvironmentRemoteBenchmark {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$Environment,
+    [Parameter(Mandatory)][hashtable]$Parameters
+  )
+  switch ($Environment) {
+    'SingleInstance' { return Invoke-SingleInstanceAwsRemoteBenchmark @Parameters }
+    'DistributedComponents' { return Invoke-DistributedComponentsAwsRemoteBenchmark @Parameters }
+    default {
+      throw "Environment '$Environment' has no remote benchmark implementation. Register it in AwsBenchmarkEnvironmentRegistry.ps1."
+    }
+  }
+}
+
+function Invoke-BenchmarkAwsEnvironmentRemove {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$Environment,
+    [Parameter(Mandatory)][object]$State,
+    [switch]$SkipSecurityGroupDelete
+  )
+  switch ($Environment) {
+    'SingleInstance' {
+      if ($SkipSecurityGroupDelete) {
+        Remove-SingleInstanceAwsBenchmarkEnvironment -State $State -SkipSecurityGroupDelete
+      } else {
+        Remove-SingleInstanceAwsBenchmarkEnvironment -State $State
+      }
+    }
+    'DistributedComponents' {
+      if ($SkipSecurityGroupDelete) {
+        Remove-DistributedComponentsAwsBenchmarkEnvironment -State $State -SkipSecurityGroupDelete
+      } else {
+        Remove-DistributedComponentsAwsBenchmarkEnvironment -State $State
+      }
+    }
+    default {
+      throw "Environment '$Environment' has no Remove implementation. Register it in AwsBenchmarkEnvironmentRegistry.ps1."
+    }
+  }
+}

--- a/scripts/cloud/Common/AwsHelpers.ps1
+++ b/scripts/cloud/Common/AwsHelpers.ps1
@@ -34,9 +34,49 @@ function New-BenchmarkSecurityGroup([string]$reg, [string]$vpcId) {
   return $sg.Trim()
 }
 
+# Allow benchmark nodes in the same security group to reach each other (Redis, SpacetimeDB, Arcane manager/clusters).
+function Add-BenchmarkDistributedIngressFromSelf {
+  param(
+    [Parameter(Mandatory)][string]$Region,
+    [Parameter(Mandatory)][string]$GroupId
+  )
+  $portRanges = @(
+    @(6379, 6379),   # Redis
+    @(3000, 3000),   # SpacetimeDB
+    @(8081, 8081),   # arcane-manager
+    @(8090, 8110)    # arcane-cluster WS
+  )
+  foreach ($pr in $portRanges) {
+    $from = $pr[0]
+    $to = $pr[1]
+    $json = "[{`"IpProtocol`":`"tcp`",`"FromPort`":$from,`"ToPort`":$to,`"UserIdGroupPairs`":[{`"GroupId`":`"$GroupId`"}]}]"
+    $tmp = Join-Path $env:TEMP ("arcane-sg-ing-$([guid]::NewGuid().ToString('n')).json")
+    [System.IO.File]::WriteAllText($tmp, $json, [System.Text.UTF8Encoding]::new($false))
+    $fileUri = Get-AwsCliFileUri $tmp
+    $raw = aws ec2 authorize-security-group-ingress --region $Region --group-id $GroupId --ip-permissions $fileUri 2>&1
+    Remove-Item -LiteralPath $tmp -Force -ErrorAction SilentlyContinue
+    if ($LASTEXITCODE -ne 0) {
+      if ("$raw" -match 'InvalidPermission\.Duplicate') { continue }
+      throw "authorize-security-group-ingress failed: $raw"
+    }
+  }
+}
+
 function Escape-BashDoubleQuoted([string]$s) {
   if ($null -eq $s) { return '' }
   return $s.Replace('\', '\\').Replace('"', '\"').Replace('$', '\$').Replace('`', '\`')
+}
+
+function Get-Ec2PrivateIp {
+  param(
+    [Parameter(Mandatory)][string]$Region,
+    [Parameter(Mandatory)][string]$InstanceId
+  )
+  $ip = aws ec2 describe-instances --region $Region --instance-ids $InstanceId --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text
+  if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($ip) -or $ip -eq 'None') {
+    throw "Could not read PrivateIpAddress for instance $InstanceId"
+  }
+  return $ip.Trim()
 }
 
 function Wait-SsmAgentOnline {
@@ -63,4 +103,62 @@ function Assert-IamInstanceProfile([string]$name) {
   if ($LASTEXITCODE -ne 0) {
     throw "IAM instance profile not found: '$name'"
   }
+}
+
+function Send-SsmRunShellScript {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$Region,
+    [Parameter(Mandatory)][string]$InstanceId,
+    [Parameter(Mandatory)][string]$ScriptBody,
+    [string]$Comment = 'Arcane benchmark SSM',
+    [int]$TimeoutSeconds = 3600
+  )
+  $paramsPath = Join-Path $env:TEMP ("arcane-ssm-$([guid]::NewGuid().ToString('n')).json")
+  try {
+    $paramObj = @{ commands = @($ScriptBody); executionTimeout = @("$TimeoutSeconds") }
+    [System.IO.File]::WriteAllText(
+      $paramsPath,
+      ($paramObj | ConvertTo-Json -Depth 10 -Compress),
+      [System.Text.UTF8Encoding]::new($false)
+    )
+    $fileUri = Get-AwsCliFileUri $paramsPath
+    $sendRaw = aws ssm send-command --region $Region --instance-ids $InstanceId --document-name 'AWS-RunShellScript' `
+      --comment $Comment --timeout-seconds $TimeoutSeconds --parameters "$fileUri" --output json 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "send-command failed: $sendRaw" }
+    $cmdId = ($sendRaw | ConvertFrom-Json).Command.CommandId
+    if ([string]::IsNullOrWhiteSpace($cmdId)) { throw 'send-command returned no CommandId' }
+    return $cmdId
+  } finally {
+    Remove-Item -LiteralPath $paramsPath -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Wait-SsmCommandInvocation {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$Region,
+    [Parameter(Mandatory)][string]$InstanceId,
+    [Parameter(Mandatory)][string]$CommandId,
+    [string]$Label = 'SSM',
+    [int]$PollSeconds = 5,
+    [switch]$ThrowOnFailure
+  )
+  Write-Host "$Label CommandId=$CommandId (waiting)..." -ForegroundColor Cyan
+  do {
+    Start-Sleep -Seconds $PollSeconds
+    $invRaw = aws ssm get-command-invocation --region $Region --command-id $CommandId --instance-id $InstanceId --output json 2>&1
+    if ($LASTEXITCODE -ne 0) { throw "get-command-invocation failed: $invRaw" }
+    $inv = $invRaw | ConvertFrom-Json
+  } while ($inv.Status -in 'Pending', 'InProgress', 'Delayed')
+
+  Write-Host "$Label Status: $($inv.Status)" -ForegroundColor $(if ($inv.Status -eq 'Success') { 'Green' } else { 'Yellow' })
+  if ($ThrowOnFailure -and $inv.Status -ne 'Success') {
+    Write-Host '--- stdout ---' -ForegroundColor DarkGray
+    $inv.StandardOutputContent
+    Write-Host '--- stderr ---' -ForegroundColor DarkGray
+    $inv.StandardErrorContent
+    throw "$Label SSM command failed: $($inv.Status)"
+  }
+  return $inv
 }

--- a/scripts/cloud/README.md
+++ b/scripts/cloud/README.md
@@ -7,9 +7,9 @@
 | **`Run-Benchmark-Aws.ps1`** | Full run: provision → SSM (clone, deps, build, `Run-Benchmark.ps1`) → stage to S3 → **download to your machine** (default: `results/runs/<Environment>/<runId>/`) → optional terminate. |
 | **`Sync-AwsBenchmarkResultsFromS3.ps1`** | **Pull-only:** copy an existing run from S3 into `results/runs/...` when the orchestrator did not download (skipped step, crash, or old tooling). |
 | **`Setup-AwsBenchmark.ps1`** | Provision only; writes a **state JSON** for later cleanup or manual SSM. |
-| **`Cleanup-AwsBenchmark.ps1`** | Tear down using **`-StatePath`** or explicit **`-InstanceId`** / **`-Region`**. |
+| **`Cleanup-AwsBenchmark.ps1`** | Tear down using **`-StatePath`** (required for **DistributedComponents**) or **`-InstanceId`** / **`-Region`** for **SingleInstance** only. |
 
-**Topology** is selected with **`-Environment`** (default `SingleInstance`). Each value maps to `environments/<Name>/`; see [environments/README.md](environments/README.md) to add another (e.g. multi-host).
+**Topology** is selected with **`-Environment`** (default `SingleInstance`). Use **`DistributedComponents`** for Redis + SpacetimeDB on **separate** instances and the benchmark driver on a third (VPC private IPs). See [environments/README.md](environments/README.md).
 
 ## Prerequisites
 

--- a/scripts/cloud/Run-Benchmark-Aws.ps1
+++ b/scripts/cloud/Run-Benchmark-Aws.ps1
@@ -12,8 +12,8 @@
   local `Run-Benchmark.ps1` run — so the person running the script has artifacts on disk when the command finishes.
   Use **-SkipLocalResultsDownload** only if you intentionally want bucket-only artifacts.
 
-  **Fail-fast:** After cloning the repo, the SSM script runs **`scripts/start-benchmark-deps.sh`** (the same
-  script you can run locally) so Redis + SpacetimeDB in Docker match between laptop and EC2.
+  **SingleInstance:** After clone, SSM runs **`scripts/start-benchmark-deps.sh`** so Redis + SpacetimeDB match local Docker.
+  **DistributedComponents:** Redis and SpacetimeDB run on **separate** instances; the driver uses **private IPs** (no `start-benchmark-deps.sh` on the driver).
 
   Requires: AWS CLI; instance profile with SSM + S3 PutObject on -ArtifactBucket; your IAM user/role needs
   **s3:GetObject** (and list) on that bucket for the post-run download.
@@ -74,6 +74,7 @@ foreach ($leaf in @('Setup.ps1', 'RemoteBenchmark.ps1', 'Cleanup.ps1')) {
   if (-not (Test-Path -LiteralPath $p)) { throw "Missing environment script: $p" }
   . $p
 }
+. (Join-Path $PSScriptRoot 'Common/AwsBenchmarkEnvironmentRegistry.ps1')
 
 Assert-AwsCli
 Assert-IamInstanceProfile -name $IamInstanceProfileName
@@ -91,23 +92,19 @@ if (-not [string]::IsNullOrWhiteSpace($resolvedGh)) {
 $runId = Get-Date -Format 'yyyyMMdd_HHmmss'
 $state = $null
 
+$initParams = @{
+  Region                 = $Region
+  InstanceType           = $InstanceType
+  RootVolumeGiB          = $RootVolumeGiB
+  SubnetId               = $SubnetId
+  SecurityGroupId        = $SecurityGroupId
+  KeyName                = $KeyName
+  IamInstanceProfileName = $IamInstanceProfileName
+  RunId                  = $runId
+}
+
 try {
-  switch ($Environment) {
-    'SingleInstance' {
-      $state = Initialize-SingleInstanceAwsBenchmarkEnvironment `
-        -Region $Region `
-        -InstanceType $InstanceType `
-        -RootVolumeGiB $RootVolumeGiB `
-        -SubnetId $SubnetId `
-        -SecurityGroupId $SecurityGroupId `
-        -KeyName $KeyName `
-        -IamInstanceProfileName $IamInstanceProfileName `
-        -RunId $runId
-    }
-    default {
-      throw "Environment '$Environment' is registered but not implemented in Run-Benchmark-Aws.ps1."
-    }
-  }
+  $state = Invoke-BenchmarkAwsEnvironmentInitialize -Environment $Environment -Parameters $initParams
 
   $state | Add-Member -NotePropertyName RunId -NotePropertyValue $runId -Force
   $state | Add-Member -NotePropertyName ArtifactBucket -NotePropertyValue $ArtifactBucket -Force
@@ -118,22 +115,17 @@ try {
     Write-Host "State saved: $StateOutPath" -ForegroundColor DarkGray
   }
 
-  switch ($Environment) {
-    'SingleInstance' {
-      $result = Invoke-SingleInstanceAwsRemoteBenchmark `
-        -State $state `
-        -RunId $runId `
-        -ArtifactBucket $ArtifactBucket `
-        -ArtifactPrefix $ArtifactPrefix `
-        -RepoUrl $RepoUrl `
-        -Branch $Branch `
-        -BenchmarkPwshArgs $BenchmarkPwshArgs `
-        -GithubTokenB64 $githubTokenB64
-    }
-    default {
-      throw "Environment '$Environment' has no remote benchmark step in Run-Benchmark-Aws.ps1."
-    }
+  $remoteParams = @{
+    State                = $state
+    RunId                = $runId
+    ArtifactBucket       = $ArtifactBucket
+    ArtifactPrefix       = $ArtifactPrefix
+    RepoUrl              = $RepoUrl
+    Branch               = $Branch
+    BenchmarkPwshArgs    = $BenchmarkPwshArgs
+    GithubTokenB64       = $githubTokenB64
   }
+  $result = Invoke-BenchmarkAwsEnvironmentRemoteBenchmark -Environment $Environment -Parameters $remoteParams
 
   if ($result.Invocation.Status -ne 'Success') { exit 1 }
 
@@ -160,9 +152,6 @@ try {
 }
 finally {
   if ($TerminateOnExit -and $null -ne $state) {
-    switch ($state.Environment) {
-      'SingleInstance' { Remove-SingleInstanceAwsBenchmarkEnvironment -State $state }
-      default { Write-Warning "No cleanup registered for environment '$($state.Environment)'." }
-    }
+    Invoke-BenchmarkAwsEnvironmentRemove -Environment $state.Environment -State $state
   }
 }

--- a/scripts/cloud/Setup-AwsBenchmark.ps1
+++ b/scripts/cloud/Setup-AwsBenchmark.ps1
@@ -43,28 +43,24 @@ if ($script:AwsBenchmarkKnownEnvironments -notcontains $Environment) {
 $setupPath = Join-Path $PSScriptRoot "environments\$Environment\Setup.ps1"
 if (-not (Test-Path -LiteralPath $setupPath)) { throw "Missing environment script: $setupPath" }
 . $setupPath
+. (Join-Path $PSScriptRoot 'Common/AwsBenchmarkEnvironmentRegistry.ps1')
 
 Assert-AwsCli
 Assert-IamInstanceProfile -name $IamInstanceProfileName
 
 $runId = Get-Date -Format 'yyyyMMdd_HHmmss'
 
-switch ($Environment) {
-  'SingleInstance' {
-    $state = Initialize-SingleInstanceAwsBenchmarkEnvironment `
-      -Region $Region `
-      -InstanceType $InstanceType `
-      -RootVolumeGiB $RootVolumeGiB `
-      -SubnetId $SubnetId `
-      -SecurityGroupId $SecurityGroupId `
-      -KeyName $KeyName `
-      -IamInstanceProfileName $IamInstanceProfileName `
-      -RunId $runId
-  }
-  default {
-    throw "Environment '$Environment' is registered but not implemented in Setup-AwsBenchmark.ps1."
-  }
+$initParams = @{
+  Region                 = $Region
+  InstanceType           = $InstanceType
+  RootVolumeGiB          = $RootVolumeGiB
+  SubnetId               = $SubnetId
+  SecurityGroupId        = $SecurityGroupId
+  KeyName                = $KeyName
+  IamInstanceProfileName = $IamInstanceProfileName
+  RunId                  = $runId
 }
+$state = Invoke-BenchmarkAwsEnvironmentInitialize -Environment $Environment -Parameters $initParams
 
 $state | Add-Member -NotePropertyName RunId -NotePropertyValue $runId -Force
 $state | Add-Member -NotePropertyName ArtifactBucket -NotePropertyValue $ArtifactBucket -Force

--- a/scripts/cloud/Tools/Import-AwsBenchmarkEnvironment.ps1
+++ b/scripts/cloud/Tools/Import-AwsBenchmarkEnvironment.ps1
@@ -4,5 +4,9 @@
 
 $script:AwsBenchmarkKnownEnvironments = @(
   'SingleInstance'
-  # Example future: 'DistributedComponents'
+  'DistributedComponents'
 )
+
+function Get-AwsBenchmarkKnownEnvironments {
+  return @($script:AwsBenchmarkKnownEnvironments)
+}

--- a/scripts/cloud/environments/DistributedComponents/Cleanup.ps1
+++ b/scripts/cloud/environments/DistributedComponents/Cleanup.ps1
@@ -1,0 +1,64 @@
+# Terminate Redis, SpacetimeDB, and driver instances; optionally delete the security group created for this run.
+# Requires: Common/AwsHelpers.ps1 dot-sourced by the caller.
+
+function Get-DistributedComponentsCleanupInstanceIdPlan {
+  [CmdletBinding()]
+  param([Parameter(Mandatory)][object]$State)
+
+  $redisId = [string]$State.RedisInstanceId
+  $stId = [string]$State.SpacetimeInstanceId
+  $benchId = [string]$State.BenchmarkInstanceId
+  $missing = [System.Collections.Generic.List[string]]::new()
+  if ([string]::IsNullOrWhiteSpace($redisId)) { [void]$missing.Add('RedisInstanceId') }
+  if ([string]::IsNullOrWhiteSpace($stId)) { [void]$missing.Add('SpacetimeInstanceId') }
+  if ([string]::IsNullOrWhiteSpace($benchId)) { [void]$missing.Add('BenchmarkInstanceId') }
+  $ids = @($redisId, $stId, $benchId) | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+
+  [pscustomobject]@{
+    MissingFieldNames      = @($missing)
+    InstanceIdsToTerminate = @($ids)
+    AllThreeMissing        = [bool]($missing.Count -eq 3)
+  }
+}
+
+function Remove-DistributedComponentsAwsBenchmarkEnvironment {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][object]$State,
+    [switch]$SkipSecurityGroupDelete
+  )
+
+  if ($State.Environment -ne 'DistributedComponents') {
+    throw "Remove-DistributedComponentsAwsBenchmarkEnvironment: state Environment must be DistributedComponents (got '$($State.Environment)')."
+  }
+
+  $region = $State.Region
+  $plan = Get-DistributedComponentsCleanupInstanceIdPlan -State $State
+  if ($plan.AllThreeMissing) {
+    throw 'DistributedComponents cleanup requires RedisInstanceId, SpacetimeInstanceId, and BenchmarkInstanceId in state. Use -StatePath from Setup-AwsBenchmark.ps1 or a Run-Benchmark-Aws.ps1 run that saved state — not manual -InstanceId (SingleInstance-only).'
+  }
+  if ($plan.MissingFieldNames.Count -gt 0) {
+    Write-Warning "State is missing: $($plan.MissingFieldNames -join ', '). Terminating only instances with known IDs."
+  }
+
+  $ids = $plan.InstanceIdsToTerminate
+  $sgId = $State.SecurityGroupId
+  $deleteSg = (-not $SkipSecurityGroupDelete) -and $State.CreatedSecurityGroup -and -not [string]::IsNullOrWhiteSpace($sgId)
+
+  if ($ids.Count -gt 0) {
+    Write-Host "Terminating instances: $($ids -join ', ') ..." -ForegroundColor Cyan
+    $termArgs = @('ec2', 'terminate-instances', '--region', $region, '--instance-ids') + $ids
+    & aws @termArgs | Out-Null
+    Write-Host 'Waiting for instances terminated...' -ForegroundColor DarkGray
+    $waitArgs = @('ec2', 'wait', 'instance-terminated', '--region', $region, '--instance-ids') + $ids
+    & aws @waitArgs 2>$null | Out-Null
+  }
+
+  if ($deleteSg) {
+    Write-Host "Deleting security group $sgId ..." -ForegroundColor Cyan
+    aws ec2 delete-security-group --region $region --group-id $sgId 2>&1 | Out-Null
+    if ($LASTEXITCODE -ne 0) {
+      Write-Warning "delete-security-group failed for $sgId (it may still be in use). Remove it manually in console."
+    }
+  }
+}

--- a/scripts/cloud/environments/DistributedComponents/README.md
+++ b/scripts/cloud/environments/DistributedComponents/README.md
@@ -1,0 +1,45 @@
+# DistributedComponents (AWS)
+
+Three EC2 instances in the **same VPC subnet** and **one security group**:
+
+| Role | Default type | Workload |
+|------|----------------|----------|
+| **Redis** | `t3.large` | Docker `redis:7-alpine` on `0.0.0.0:6379` |
+| **SpacetimeDB** | `t3.large` | Docker `clockworklabs/spacetime:latest` on `0.0.0.0:3000` |
+| **Driver** | `-InstanceType` (e.g. `c7i.2xlarge`) | Clone repo, Rust builds, `spacetime publish` to Spacetime **private IP**, `Run-Benchmark.ps1` with `-RedisHost` / `-SpacetimeHost` set to those private IPs |
+
+Traffic between Redis, SpacetimeDB, and Arcane (on the driver) uses **VPC private networking** (not loopback), so inter-component RTT reflects a real cloud path more than single-host Docker Desktop.
+
+## Usage
+
+Same orchestrator as `SingleInstance`, different environment name:
+
+```powershell
+cd scripts/cloud
+.\Run-Benchmark-Aws.ps1 `
+  -Environment DistributedComponents `
+  -ArtifactBucket <bucket> `
+  -IamInstanceProfileName <profile> `
+  -Region us-east-1 `
+  -TerminateOnExit
+```
+
+Results land under `results/runs/DistributedComponents/<RunId>/` locally (and the same prefix on S3).
+
+## Teardown
+
+This topology creates **three** instances. **Always use the saved state JSON** for cleanup:
+
+- Pass **`-StatePath`** to `Cleanup-AwsBenchmark.ps1` (from `Setup-AwsBenchmark.ps1` or `-StateOutPath` on `Run-Benchmark-Aws.ps1`).
+- **Do not** use the manual **`-InstanceId`** mode from `Cleanup-AwsBenchmark.ps1`; it is only valid for **SingleInstance** and would not terminate Redis, SpacetimeDB, and the driver together.
+
+## Security group
+
+If you omit `-SecurityGroupId`, a temporary group is created and **ingress from the same security group** is added for TCP **6379, 3000, 8081, 8090–8110** (Arcane manager + cluster WS range). If you pass your own group, the setup script **adds** those rules (duplicates are ignored).
+
+**SSM** still needs the instance profile with `AmazonSSMManagedInstanceCore` (no SSH required).
+
+## Limitations (v1)
+
+- **Arcane manager + clusters + swarm** still run on the **driver** only. Redis and SpacetimeDB are the components split onto separate machines. Further splits (e.g. one instance per Arcane cluster) can build on this pattern.
+- **Three instances** = higher cost than `SingleInstance`; data nodes use `t3.large` by default to keep cost down.

--- a/scripts/cloud/environments/DistributedComponents/RemoteBenchmark.ps1
+++ b/scripts/cloud/environments/DistributedComponents/RemoteBenchmark.ps1
@@ -1,0 +1,181 @@
+# Start Redis + SpacetimeDB on dedicated instances, then clone/build/run Run-Benchmark.ps1 on the driver (private VPC IPs).
+# Requires: Common/AwsHelpers.ps1 dot-sourced by the caller.
+
+function Invoke-DistributedComponentsAwsRemoteBenchmark {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][object]$State,
+    [Parameter(Mandatory)][string]$RunId,
+    [Parameter(Mandatory)][string]$ArtifactBucket,
+    [string]$ArtifactPrefix = 'benchmark-aws',
+    [Parameter(Mandatory)][string]$RepoUrl,
+    [Parameter(Mandatory)][string]$Branch,
+    [string]$BenchmarkPwshArgs = '',
+    [string]$GithubTokenB64 = ''
+  )
+
+  if ($State.Environment -ne 'DistributedComponents') {
+    throw "Invoke-DistributedComponentsAwsRemoteBenchmark: state Environment must be DistributedComponents (got '$($State.Environment)')."
+  }
+
+  $Region = $State.Region
+  $redisId = $State.RedisInstanceId
+  $spacetimeId = $State.SpacetimeInstanceId
+  $benchId = $State.BenchmarkInstanceId
+  $remoteRoot = $State.RemoteRoot
+  $envSeg = 'DistributedComponents'
+  $remoteOutDir = "$remoteRoot/results/runs/$envSeg/$RunId"
+  $s3Dest = "s3://$ArtifactBucket/$ArtifactPrefix/$envSeg/$RunId/"
+
+  $redisIp = Get-Ec2PrivateIp -Region $Region -InstanceId $redisId
+  $stIp = Get-Ec2PrivateIp -Region $Region -InstanceId $spacetimeId
+  Write-Host "Private IPs: Redis=$redisIp SpacetimeDB=$stIp (driver=$benchId)" -ForegroundColor DarkGray
+
+  $redisScript = @'
+set -euo pipefail
+export PATH="/usr/local/bin:$PATH"
+for i in $(seq 1 90); do docker info >/dev/null 2>&1 && break; sleep 5; done
+docker rm -f arcane-bench-redis 2>/dev/null || true
+docker run -d --name arcane-bench-redis -p 0.0.0.0:6379:6379 redis:7-alpine redis-server --appendonly yes
+for i in $(seq 1 90); do docker exec arcane-bench-redis redis-cli ping 2>/dev/null | grep -q PONG && exit 0; sleep 1; done
+exit 1
+'@
+
+  $stScript = @'
+set -euo pipefail
+export PATH="/usr/local/bin:$PATH"
+for i in $(seq 1 90); do docker info >/dev/null 2>&1 && break; sleep 5; done
+ST_IMAGE="${ST_IMAGE:-clockworklabs/spacetime:latest}"
+docker rm -f arcane-bench-spacetime 2>/dev/null || true
+docker pull "$ST_IMAGE"
+docker run -d --name arcane-bench-spacetime -p 0.0.0.0:3000:3000 "$ST_IMAGE" start
+for i in $(seq 1 120); do bash -c "echo >/dev/tcp/127.0.0.1/3000" 2>/dev/null && exit 0; sleep 2; done
+exit 1
+'@
+
+  $cidR = Send-SsmRunShellScript -Region $Region -InstanceId $redisId -ScriptBody $redisScript `
+    -Comment "Arcane bench redis $RunId" -TimeoutSeconds 1200
+  $null = Wait-SsmCommandInvocation -Region $Region -InstanceId $redisId -CommandId $cidR -Label 'Redis' `
+    -PollSeconds 5 -ThrowOnFailure
+
+  $cidS = Send-SsmRunShellScript -Region $Region -InstanceId $spacetimeId -ScriptBody $stScript `
+    -Comment "Arcane bench spacetime $RunId" -TimeoutSeconds 3600
+  $null = Wait-SsmCommandInvocation -Region $Region -InstanceId $spacetimeId -CommandId $cidS -Label 'SpacetimeDB' `
+    -PollSeconds 5 -ThrowOnFailure
+
+  $benchB64 = ''
+  if (-not [string]::IsNullOrWhiteSpace($BenchmarkPwshArgs)) {
+    $benchB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($BenchmarkPwshArgs.Trim()))
+  }
+  $ghB64 = if ([string]::IsNullOrWhiteSpace($GithubTokenB64)) { '' } else { $GithubTokenB64.Trim() }
+
+  $remoteTpl = @'
+#!/bin/bash
+set -euo pipefail
+export HOME="${HOME:-/root}"
+export PATH="/usr/local/bin:/root/.local/bin:$PATH"
+export REPO_URL="__REPO__"
+export BRANCH="__BRANCH__"
+export REMOTE_ROOT="__ROOT__"
+export REMOTE_OUT="__OUT__"
+export S3_DEST="__S3__"
+export AWS_REGION="__REGION__"
+export BENCH_B64="__BENCH_B64__"
+export REDIS_IP="__REDIS_IP__"
+export ST_IP="__ST_IP__"
+GITHUB_TOKEN_B64="__GITHUB_TOKEN_B64__"
+
+until command -v pwsh >/dev/null 2>&1 && command -v spacetime >/dev/null 2>&1; do
+  echo "waiting for user-data (driver)..."
+  sleep 10
+done
+
+echo "=== Verify reachability to Redis + SpacetimeDB over VPC ==="
+for i in $(seq 1 60); do bash -c "echo >/dev/tcp/$REDIS_IP/6379" 2>/dev/null && break; sleep 2; done
+bash -c "echo >/dev/tcp/$REDIS_IP/6379" 2>/dev/null || { echo "ERROR: cannot reach Redis at $REDIS_IP:6379"; exit 1; }
+for i in $(seq 1 60); do bash -c "echo >/dev/tcp/$ST_IP/3000" 2>/dev/null && break; sleep 2; done
+bash -c "echo >/dev/tcp/$ST_IP/3000" 2>/dev/null || { echo "ERROR: cannot reach SpacetimeDB at $ST_IP:3000"; exit 1; }
+
+echo "=== Clone repository ==="
+mkdir -p "$(dirname "$REMOTE_ROOT")"
+if [ ! -d "$REMOTE_ROOT/.git" ]; then
+  git clone "$REPO_URL" "$REMOTE_ROOT"
+fi
+cd "$REMOTE_ROOT"
+git fetch origin
+if ! git checkout "$BRANCH"; then
+  git checkout master || git checkout main
+fi
+git pull --ff-only || git pull
+
+echo "=== Toolchain + submodules + builds (no local Docker deps on driver) ==="
+apt-get update -y
+apt-get install -y binaryen pkg-config libssl-dev build-essential || true
+if ! command -v rustc >/dev/null 2>&1; then
+  curl -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+fi
+if [ -f "$HOME/.cargo/env" ]; then . "$HOME/.cargo/env"; fi
+rustup target add wasm32-unknown-unknown || true
+export PATH="$HOME/.cargo/bin:/root/.local/bin:$PATH"
+
+if [ -n "$GITHUB_TOKEN_B64" ]; then
+  _GH_TOKEN=$(printf '%s' "$GITHUB_TOKEN_B64" | base64 -d)
+  git config --global url."https://x-access-token:${_GH_TOKEN}@github.com/".insteadOf "https://github.com/"
+  unset _GH_TOKEN
+fi
+git submodule update --init --recursive
+
+(cd arcane_swarm && cargo build -p arcane-swarm --bin arcane-swarm --release)
+(cd arcane && cargo build -p arcane-infra --bin arcane-manager --features manager --release)
+(cd arcane && cargo build -p arcane-infra --bin arcane-cluster --features cluster-ws --release)
+
+ST_URL="http://${ST_IP}:3000"
+(cd spacetimedb_demo/spacetimedb && spacetime build && spacetime publish arcane --yes --anonymous -s "$ST_URL")
+
+mkdir -p "$REMOTE_OUT"
+set +e
+if [ -n "$BENCH_B64" ]; then
+  EXTRA=$(printf '%s' "$BENCH_B64" | base64 -d)
+  pwsh -NoProfile -Command "& \"${REMOTE_ROOT}/scripts/Run-Benchmark.ps1\" -OutDir \"${REMOTE_OUT}\" -RedisHost \"${REDIS_IP}\" -RedisPort 6379 -SpacetimeHost \"${ST_URL}\" -Environment DistributedComponents ${EXTRA}"
+else
+  pwsh -NoProfile -Command "& \"${REMOTE_ROOT}/scripts/Run-Benchmark.ps1\" -OutDir \"${REMOTE_OUT}\" -RedisHost \"${REDIS_IP}\" -RedisPort 6379 -SpacetimeHost \"${ST_URL}\" -Environment DistributedComponents"
+fi
+EC=$?
+set -e
+
+aws s3 sync "$REMOTE_OUT" "$S3_DEST" --region "$AWS_REGION"
+echo "Benchmark exit code: $EC"
+exit $EC
+'@
+
+  $remoteBash = $remoteTpl.
+    Replace('__REPO__', (Escape-BashDoubleQuoted $RepoUrl)).
+    Replace('__BRANCH__', (Escape-BashDoubleQuoted $Branch)).
+    Replace('__ROOT__', (Escape-BashDoubleQuoted $remoteRoot)).
+    Replace('__OUT__', (Escape-BashDoubleQuoted $remoteOutDir)).
+    Replace('__S3__', (Escape-BashDoubleQuoted $s3Dest)).
+    Replace('__REGION__', (Escape-BashDoubleQuoted $Region)).
+    Replace('__BENCH_B64__', $benchB64).
+    Replace('__REDIS_IP__', (Escape-BashDoubleQuoted $redisIp)).
+    Replace('__ST_IP__', (Escape-BashDoubleQuoted $stIp)).
+    Replace('__GITHUB_TOKEN_B64__', $ghB64)
+  $remoteBash = $remoteBash -replace "`r`n", "`n"
+
+  Write-Host 'Sending driver SSM run command (long)...' -ForegroundColor Cyan
+  $cmdId = Send-SsmRunShellScript -Region $Region -InstanceId $benchId -ScriptBody $remoteBash `
+    -Comment "Arcane distributed benchmark $RunId" -TimeoutSeconds 28800
+
+  $inv = Wait-SsmCommandInvocation -Region $Region -InstanceId $benchId -CommandId $cmdId -Label 'Driver SSM' -PollSeconds 10
+  Write-Host '--- stdout (tail) ---' -ForegroundColor DarkGray
+  ($inv.StandardOutputContent -split "`n" | Select-Object -Last 80) -join "`n"
+  Write-Host '--- stderr (tail) ---' -ForegroundColor DarkGray
+  ($inv.StandardErrorContent -split "`n" | Select-Object -Last 40) -join "`n"
+
+  Write-Host "Staged to S3: $s3Dest" -ForegroundColor Green
+
+  [pscustomobject]@{
+    Invocation = $inv
+    S3Dest     = $s3Dest
+    RunId      = $RunId
+  }
+}

--- a/scripts/cloud/environments/DistributedComponents/Setup.ps1
+++ b/scripts/cloud/environments/DistributedComponents/Setup.ps1
@@ -1,0 +1,133 @@
+# Three EC2 instances: Redis (Docker), SpacetimeDB (Docker), benchmark driver (pwsh + Rust builds + swarm + Arcane).
+# Same VPC/subnet and one security group; private IPs used for inter-node traffic.
+# Requires: Common/AwsHelpers.ps1 dot-sourced by the caller.
+
+function Initialize-DistributedComponentsAwsBenchmarkEnvironment {
+  [CmdletBinding()]
+  param(
+    [Parameter(Mandatory)][string]$Region,
+    [Parameter(Mandatory)][string]$InstanceType,
+    [Parameter(Mandatory)][int]$RootVolumeGiB,
+    [string]$SubnetId = '',
+    [string]$SecurityGroupId = '',
+    [string]$KeyName = '',
+    [Parameter(Mandatory)][string]$IamInstanceProfileName,
+    [Parameter(Mandatory)][string]$RunId
+  )
+
+  $remoteRoot = '/opt/arcane-scaling-benchmarks'
+  $ami = Get-Ubuntu2204Ami $Region
+  $rootDev = aws ec2 describe-images --region $Region --image-ids $ami --query 'Images[0].RootDeviceName' --output text
+  if ([string]::IsNullOrWhiteSpace($rootDev) -or $rootDev -eq 'None') { $rootDev = '/dev/sda1' }
+  $rootDev = $rootDev.Trim()
+  $bdmPath = Join-Path $env:TEMP ("arcane-bdm-dist-$RunId.json")
+  $bdmBody = @"
+[{"DeviceName":"$rootDev","Ebs":{"VolumeSize":$RootVolumeGiB,"VolumeType":"gp3","DeleteOnTermination":true}}]
+"@
+  [System.IO.File]::WriteAllText($bdmPath, $bdmBody.Trim(), [System.Text.UTF8Encoding]::new($false))
+  $bdmUri = Get-AwsCliFileUri $bdmPath
+
+  if ([string]::IsNullOrWhiteSpace($SubnetId)) {
+    $SubnetId = Get-DefaultSubnet $Region
+  }
+  $vpcForSg = aws ec2 describe-subnets --region $Region --subnet-ids $SubnetId --query 'Subnets[0].VpcId' --output text
+  $createdSg = $false
+  if ([string]::IsNullOrWhiteSpace($SecurityGroupId)) {
+    Write-Host "No -SecurityGroupId; creating temporary SG in VPC $vpcForSg" -ForegroundColor Yellow
+    $SecurityGroupId = New-BenchmarkSecurityGroup -reg $Region -vpcId $vpcForSg.Trim()
+    $createdSg = $true
+  }
+  else {
+    $SecurityGroupId = $SecurityGroupId.Trim()
+  }
+  Add-BenchmarkDistributedIngressFromSelf -Region $Region -GroupId $SecurityGroupId
+
+  $userDataDockerOnly = @'
+#!/bin/bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y ca-certificates curl gnupg
+install -m 0755 -d /etc/apt/keyrings
+curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
+chmod a+r /etc/apt/keyrings/docker.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+systemctl enable --now docker
+'@
+
+  $userDataBenchmark = @'
+#!/bin/bash
+set -euo pipefail
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y ca-certificates curl git gnupg unzip pkg-config libssl-dev build-essential
+curl -sSf https://install.spacetimedb.com | sh -s -- -y
+export PATH="/root/.local/bin:$PATH"
+curl -LO https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/powershell_7.4.6-1.deb_amd64.deb
+dpkg -i powershell_7.4.6-1.deb_amd64.deb || apt-get install -f -y
+rm -f powershell_7.4.6-1.deb_amd64.deb
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp && /tmp/aws/install && rm -rf /tmp/aws /tmp/awscliv2.zip
+'@
+
+  $dataInstanceType = 't3.large'
+
+  function Invoke-LaunchOne {
+    param(
+      [string]$NameSuffix,
+      [string]$UserDataText,
+      [string]$InstType
+    )
+    $udB64 = [Convert]::ToBase64String([Text.Encoding]::UTF8.GetBytes($UserDataText))
+    $runArgs = @(
+      'ec2', 'run-instances',
+      '--region', $Region,
+      '--image-id', $ami,
+      '--instance-type', $InstType,
+      '--subnet-id', $SubnetId,
+      '--security-group-ids', $SecurityGroupId,
+      '--iam-instance-profile', "Name=$IamInstanceProfileName",
+      '--block-device-mappings', $bdmUri,
+      '--user-data', $udB64,
+      '--tag-specifications', "ResourceType=instance,Tags=[{Key=Name,Value=arcane-bench-$NameSuffix-$RunId}]",
+      '--metadata-options', 'HttpTokens=required',
+      '--query', 'Instances[0].InstanceId',
+      '--output', 'text'
+    )
+    if (-not [string]::IsNullOrWhiteSpace($KeyName)) {
+      $runArgs += @('--key-name', $KeyName)
+    }
+    Write-Host "Launching $NameSuffix ($InstType)..." -ForegroundColor Cyan
+    $id = (& aws @runArgs).Trim()
+    if ($LASTEXITCODE -ne 0 -or [string]::IsNullOrWhiteSpace($id)) { throw "run-instances failed for $NameSuffix" }
+    return $id
+  }
+
+  $redisId = Invoke-LaunchOne -NameSuffix 'redis' -UserDataText $userDataDockerOnly -InstType $dataInstanceType
+  $spacetimeId = Invoke-LaunchOne -NameSuffix 'spacetime' -UserDataText $userDataDockerOnly -InstType $dataInstanceType
+  $benchmarkId = Invoke-LaunchOne -NameSuffix 'driver' -UserDataText $userDataBenchmark -InstType $InstanceType
+
+  Remove-Item -LiteralPath $bdmPath -Force -ErrorAction SilentlyContinue
+
+  Write-Host 'Waiting for instances running...' -ForegroundColor Cyan
+  aws ec2 wait instance-running --region $Region --instance-ids $redisId $spacetimeId $benchmarkId | Out-Null
+
+  Wait-SsmAgentOnline -Region $Region -InstanceId $redisId
+  Wait-SsmAgentOnline -Region $Region -InstanceId $spacetimeId
+  Wait-SsmAgentOnline -Region $Region -InstanceId $benchmarkId
+
+  [pscustomobject]@{
+    Environment             = 'DistributedComponents'
+    Region                  = $Region
+    RedisInstanceId         = $redisId
+    SpacetimeInstanceId     = $spacetimeId
+    BenchmarkInstanceId     = $benchmarkId
+    SecurityGroupId         = $SecurityGroupId
+    CreatedSecurityGroup    = $createdSg
+    RemoteRoot              = $remoteRoot
+    SubnetId                = $SubnetId
+    IamInstanceProfileName  = $IamInstanceProfileName
+  }
+}

--- a/scripts/cloud/environments/README.md
+++ b/scripts/cloud/environments/README.md
@@ -10,14 +10,14 @@ Each subdirectory is one **environment**: a way to provision infrastructure and 
 | `RemoteBenchmark.ps1` | Dot-sourced. Defines `Invoke-<EnvName>AwsRemoteBenchmark` — typically SSM or SSH steps that end with `Run-Benchmark.ps1` and artifact upload. |
 | `Cleanup.ps1` | Dot-sourced. Defines `Remove-<EnvName>AwsBenchmarkEnvironment` — terminate instances, delete security groups this run created, etc. |
 
-Shared helpers live in **`../Common/AwsHelpers.ps1`**.
+Shared helpers live in **`../Common/AwsHelpers.ps1`**. Environment routing (which `Initialize-*` / `Invoke-*` / `Remove-*` to call) is centralized in **`../Common/AwsBenchmarkEnvironmentRegistry.ps1`** — add a `switch` arm there when you introduce a new topology.
 
 ## Registering a new environment
 
 1. Copy `SingleInstance/` to a new folder (e.g. `DistributedComponents/`).
 2. Implement setup / remote run / cleanup for that topology.
 3. Append the folder name to **`$script:AwsBenchmarkKnownEnvironments`** in [`../Tools/Import-AwsBenchmarkEnvironment.ps1`](../Tools/Import-AwsBenchmarkEnvironment.ps1).
-4. Ensure **`Run-Benchmark-Aws.ps1`** dot-sources your three scripts under `environments/<Name>/` (alongside **`Common/AwsHelpers.ps1`** at script scope). Update **`Setup-AwsBenchmark.ps1`** / **`Cleanup-AwsBenchmark.ps1`** if they need new `switch` arms for `Initialize-*` / `Remove-*`.
+4. Add **`Initialize-*`**, **`Invoke-*`**, and **`Remove-*`** entries for your folder name in [`../Common/AwsBenchmarkEnvironmentRegistry.ps1`](../Common/AwsBenchmarkEnvironmentRegistry.ps1). **`Run-Benchmark-Aws.ps1`** already dot-sources every file under `environments/<Name>/` plus that registry.
 
 The **state object** should always include an **`Environment`** property matching the folder name so cleanup scripts can branch correctly.
 
@@ -26,3 +26,4 @@ The **state object** should always include an **`Environment`** property matchin
 | Name | Description |
 |------|-------------|
 | `SingleInstance` | One EC2 host: Docker (Redis + SpacetimeDB), Rust builds, swarm + Arcane, then `Run-Benchmark.ps1` via SSM. |
+| `DistributedComponents` | Three EC2 instances: Redis (Docker), SpacetimeDB (Docker), and a **driver** that builds and runs `Run-Benchmark.ps1` against **private VPC IPs** (real inter-VM networking for deps). See [DistributedComponents/README.md](DistributedComponents/README.md). |

--- a/scripts/cloud/environments/SingleInstance/RemoteBenchmark.ps1
+++ b/scripts/cloud/environments/SingleInstance/RemoteBenchmark.ps1
@@ -117,45 +117,11 @@ exit $EC
     Replace('__GITHUB_TOKEN_B64__', $ghB64)
   $remoteBash = $remoteBash -replace "`r`n", "`n"
 
-  $paramsPath = Join-Path $env:TEMP "arcane-ssm-params-$RunId.json"
-  # AWS-RunShellScript executionTimeout is seconds (default 3600); max 172800. Full benchmark + cold build needs longer.
-  $paramObj = @{
-    commands           = @($remoteBash)
-    executionTimeout   = @('28800')
-  }
-  $jsonParams = $paramObj | ConvertTo-Json -Depth 10 -Compress
-  [System.IO.File]::WriteAllText($paramsPath, $jsonParams, [System.Text.UTF8Encoding]::new($false))
-
-  $fileUri = Get-AwsCliFileUri $paramsPath
-
   Write-Host 'Sending SSM run command...' -ForegroundColor Cyan
-  $sendRaw = aws ssm send-command --region $Region `
-    --instance-ids $instanceId `
-    --document-name 'AWS-RunShellScript' `
-    --comment "Arcane benchmark $RunId" `
-    --timeout-seconds 28800 `
-    --parameters "$fileUri" `
-    --output json 2>&1
-  if ($LASTEXITCODE -ne 0) {
-    Remove-Item -LiteralPath $paramsPath -Force -ErrorAction SilentlyContinue
-    throw "send-command failed: $sendRaw"
-  }
-  $sendOut = $sendRaw | ConvertFrom-Json
+  $cmdId = Send-SsmRunShellScript -Region $Region -InstanceId $instanceId -ScriptBody $remoteBash `
+    -Comment "Arcane benchmark $RunId" -TimeoutSeconds 28800
 
-  $cmdId = $sendOut.Command.CommandId
-  Remove-Item -LiteralPath $paramsPath -Force -ErrorAction SilentlyContinue
-
-  if ([string]::IsNullOrWhiteSpace($cmdId)) { throw 'send-command returned no CommandId' }
-
-  Write-Host "CommandId=$cmdId (waiting)..." -ForegroundColor Cyan
-  do {
-    Start-Sleep -Seconds 10
-    $invRaw = aws ssm get-command-invocation --region $Region --command-id $cmdId --instance-id $instanceId --output json 2>&1
-    if ($LASTEXITCODE -ne 0) { throw "get-command-invocation failed: $invRaw" }
-    $inv = $invRaw | ConvertFrom-Json
-  } while ($inv.Status -in 'Pending', 'InProgress', 'Delayed')
-
-  Write-Host "SSM Status: $($inv.Status)" -ForegroundColor $(if ($inv.Status -eq 'Success') { 'Green' } else { 'Yellow' })
+  $inv = Wait-SsmCommandInvocation -Region $Region -InstanceId $instanceId -CommandId $cmdId -Label 'SSM' -PollSeconds 10
   Write-Host '--- stdout (tail) ---' -ForegroundColor DarkGray
   ($inv.StandardOutputContent -split "`n" | Select-Object -Last 80) -join "`n"
   Write-Host '--- stderr (tail) ---' -ForegroundColor DarkGray

--- a/tests/BenchmarkHarnessHelpers.Tests.ps1
+++ b/tests/BenchmarkHarnessHelpers.Tests.ps1
@@ -1,0 +1,55 @@
+BeforeAll {
+  $helpers = Join-Path $PSScriptRoot '..\scripts\BenchmarkHarnessHelpers.ps1'
+  . $helpers
+}
+
+Describe 'Get-SafeResultsEnvironmentSegment' {
+  It 'returns Local for empty or whitespace' {
+    Get-SafeResultsEnvironmentSegment '' | Should -Be 'Local'
+    Get-SafeResultsEnvironmentSegment '   ' | Should -Be 'Local'
+    Get-SafeResultsEnvironmentSegment $null | Should -Be 'Local'
+  }
+
+  It 'passes through safe names' {
+    Get-SafeResultsEnvironmentSegment 'Local' | Should -Be 'Local'
+    Get-SafeResultsEnvironmentSegment 'DistributedComponents' | Should -Be 'DistributedComponents'
+    Get-SafeResultsEnvironmentSegment 'SingleInstance' | Should -Be 'SingleInstance'
+  }
+
+  It 'replaces Windows-invalid path characters with underscore' {
+    Get-SafeResultsEnvironmentSegment 'a/b' | Should -Be 'a_b'
+    Get-SafeResultsEnvironmentSegment 'x:y' | Should -Be 'x_y'
+    Get-SafeResultsEnvironmentSegment 'a|b*c?d<e>f"g\h' | Should -Be 'a_b_c_d_e_f_g_h'
+  }
+
+}
+
+Describe 'Merge-ConfigFileParameters' {
+  BeforeEach {
+    $script:SpacetimeMaxPlayers = 1
+    $script:Environment = 'Local'
+  }
+
+  It 'no-ops when path is empty' {
+    { Merge-ConfigFileParameters -Path '' } | Should -Not -Throw
+    $script:SpacetimeMaxPlayers | Should -Be 1
+  }
+
+  It 'applies supported keys from JSON' {
+    $p = Join-Path $TestDrive 'bench.json'
+    (@{ SpacetimeMaxPlayers = 4242; Environment = 'SingleInstance' } | ConvertTo-Json) | Set-Content -LiteralPath $p -Encoding utf8
+    Merge-ConfigFileParameters -Path $p
+    $script:SpacetimeMaxPlayers | Should -Be 4242
+    $script:Environment | Should -Be 'SingleInstance'
+  }
+
+  It 'throws on unsupported keys' {
+    $p = Join-Path $TestDrive 'bad.json'
+    (@{ NotARealKey = 1 } | ConvertTo-Json) | Set-Content -LiteralPath $p -Encoding utf8
+    { Merge-ConfigFileParameters -Path $p } | Should -Throw '*Unsupported config key*'
+  }
+
+  It 'throws when file missing' {
+    { Merge-ConfigFileParameters -Path (Join-Path $TestDrive 'nope.json') } | Should -Throw '*not found*'
+  }
+}

--- a/tests/Cloud.AwsHelpers.Tests.ps1
+++ b/tests/Cloud.AwsHelpers.Tests.ps1
@@ -1,0 +1,36 @@
+BeforeAll {
+  $h = Join-Path $PSScriptRoot '..\scripts\cloud\Common\AwsHelpers.ps1'
+  . $h
+}
+
+Describe 'Escape-BashDoubleQuoted' {
+  It 'returns empty string for null' {
+    Escape-BashDoubleQuoted $null | Should -Be ''
+  }
+
+  It 'escapes characters that break double-quoted bash strings' {
+    Escape-BashDoubleQuoted 'a\b' | Should -Be 'a\\b'
+    Escape-BashDoubleQuoted 'say "hi"' | Should -Be 'say \"hi\"'
+    Escape-BashDoubleQuoted 'echo $PATH' | Should -Be 'echo \$PATH'
+    Escape-BashDoubleQuoted 'cmd `sub`' | Should -Be 'cmd \`sub\`'
+  }
+
+  It 'handles combined special characters' {
+    Escape-BashDoubleQuoted '\$"`' | Should -Be '\\\$\"\`'
+  }
+}
+
+Describe 'Get-AwsCliFileUri' {
+  It 'returns an AWS-CLI-compatible file URI including the target file name' {
+    $tmp = Join-Path $TestDrive 'params.json'
+    '{}' | Set-Content -LiteralPath $tmp
+    $uri = Get-AwsCliFileUri $tmp
+    $uri | Should -Match '^file://'
+    $uri | Should -Match 'params\.json'
+    if ($tmp -match '^[A-Za-z]:\\') {
+      $uri | Should -Match '^file://[A-Za-z]:\\'
+    } else {
+      $uri | Should -Match '^file:///'
+    }
+  }
+}

--- a/tests/Cloud.DistributedCleanup.Tests.ps1
+++ b/tests/Cloud.DistributedCleanup.Tests.ps1
@@ -1,0 +1,42 @@
+BeforeAll {
+  $cleanup = Join-Path $PSScriptRoot '..\scripts\cloud\environments\DistributedComponents\Cleanup.ps1'
+  . $cleanup
+}
+
+Describe 'Get-DistributedComponentsCleanupInstanceIdPlan' {
+  It 'marks all three missing when no ids' {
+    $s = [pscustomobject]@{
+      RedisInstanceId     = ''
+      SpacetimeInstanceId = $null
+      BenchmarkInstanceId = '  '
+    }
+    $p = Get-DistributedComponentsCleanupInstanceIdPlan -State $s
+    $p.AllThreeMissing | Should -BeTrue
+    $p.InstanceIdsToTerminate.Count | Should -Be 0
+    $p.MissingFieldNames.Count | Should -Be 3
+  }
+
+  It 'lists only non-empty instance ids' {
+    $s = [pscustomobject]@{
+      RedisInstanceId     = 'i-redis'
+      SpacetimeInstanceId = ''
+      BenchmarkInstanceId = 'i-bench'
+    }
+    $p = Get-DistributedComponentsCleanupInstanceIdPlan -State $s
+    $p.AllThreeMissing | Should -BeFalse
+    $p.InstanceIdsToTerminate | Should -Be @('i-redis', 'i-bench')
+    $p.MissingFieldNames | Should -Be @('SpacetimeInstanceId')
+  }
+
+  It 'returns all three ids when complete' {
+    $s = [pscustomobject]@{
+      RedisInstanceId     = 'r'
+      SpacetimeInstanceId = 's'
+      BenchmarkInstanceId = 'b'
+    }
+    $p = Get-DistributedComponentsCleanupInstanceIdPlan -State $s
+    $p.AllThreeMissing | Should -BeFalse
+    $p.MissingFieldNames.Count | Should -Be 0
+    $p.InstanceIdsToTerminate | Should -Be @('r', 's', 'b')
+  }
+}

--- a/tests/Cloud.EnvironmentRegistry.Tests.ps1
+++ b/tests/Cloud.EnvironmentRegistry.Tests.ps1
@@ -1,0 +1,31 @@
+BeforeAll {
+  $root = Join-Path $PSScriptRoot '..\scripts\cloud'
+  . (Join-Path $root 'Common\AwsBenchmarkEnvironmentRegistry.ps1')
+  . (Join-Path $root 'Tools\Import-AwsBenchmarkEnvironment.ps1')
+}
+
+Describe 'Import-AwsBenchmarkEnvironment' {
+  It 'includes SingleInstance and DistributedComponents' {
+    $names = Get-AwsBenchmarkKnownEnvironments
+    $names | Should -Contain 'SingleInstance'
+    $names | Should -Contain 'DistributedComponents'
+  }
+}
+
+Describe 'AwsBenchmarkEnvironmentRegistry' {
+  It 'throws for unknown environment on Initialize' {
+    { Invoke-BenchmarkAwsEnvironmentInitialize -Environment 'NoSuchTopology' -Parameters @{} } |
+      Should -Throw '*Initialize implementation*'
+  }
+
+  It 'throws for unknown environment on RemoteBenchmark' {
+    { Invoke-BenchmarkAwsEnvironmentRemoteBenchmark -Environment 'NoSuchTopology' -Parameters @{} } |
+      Should -Throw '*remote benchmark*'
+  }
+
+  It 'throws for unknown environment on Remove' {
+    $fake = [pscustomobject]@{ Environment = 'SingleInstance' }
+    { Invoke-BenchmarkAwsEnvironmentRemove -Environment 'NoSuchTopology' -State $fake } |
+      Should -Throw '*Remove implementation*'
+  }
+}

--- a/tests/Layout.Tests.ps1
+++ b/tests/Layout.Tests.ps1
@@ -10,6 +10,11 @@ Describe 'Benchmark repository layout' {
     Test-Path -LiteralPath $p | Should -Be $true
   }
 
+  It 'exposes shared benchmark harness helpers' {
+    $p = Join-Path $PSScriptRoot '..\scripts\BenchmarkHarnessHelpers.ps1'
+    Test-Path -LiteralPath $p | Should -Be $true
+  }
+
   It 'exposes optional AWS launcher' {
     $p = Join-Path $PSScriptRoot '..\scripts\cloud\Run-Benchmark-Aws.ps1'
     Test-Path -LiteralPath $p | Should -Be $true
@@ -21,10 +26,18 @@ Describe 'Benchmark repository layout' {
     Test-Path -LiteralPath (Join-Path $root 'Cleanup-AwsBenchmark.ps1') | Should -Be $true
     Test-Path -LiteralPath (Join-Path (Join-Path $root 'Tools') 'Import-AwsBenchmarkEnvironment.ps1') | Should -Be $true
     Test-Path -LiteralPath (Join-Path (Join-Path $root 'Common') 'AwsHelpers.ps1') | Should -Be $true
+    Test-Path -LiteralPath (Join-Path (Join-Path $root 'Common') 'AwsBenchmarkEnvironmentRegistry.ps1') | Should -Be $true
   }
 
   It 'exposes SingleInstance environment module' {
     $base = Join-Path (Join-Path (Join-Path $PSScriptRoot '..\scripts\cloud') 'environments') 'SingleInstance'
+    Test-Path -LiteralPath (Join-Path $base 'Setup.ps1') | Should -Be $true
+    Test-Path -LiteralPath (Join-Path $base 'RemoteBenchmark.ps1') | Should -Be $true
+    Test-Path -LiteralPath (Join-Path $base 'Cleanup.ps1') | Should -Be $true
+  }
+
+  It 'exposes DistributedComponents environment module' {
+    $base = Join-Path (Join-Path (Join-Path $PSScriptRoot '..\scripts\cloud') 'environments') 'DistributedComponents'
     Test-Path -LiteralPath (Join-Path $base 'Setup.ps1') | Should -Be $true
     Test-Path -LiteralPath (Join-Path $base 'RemoteBenchmark.ps1') | Should -Be $true
     Test-Path -LiteralPath (Join-Path $base 'Cleanup.ps1') | Should -Be $true


### PR DESCRIPTION
## Summary

This PR updates the **arcane-scaling-benchmarks** repo and the **`arcane_swarm` submodule** to ship a clearer error story, deterministic load spikes, safer AWS cleanup, and optional multi-instance dependencies on AWS.

### arcane_swarm (submodule)

- **Error taxonomy** in `FINAL:` output (`err_json` + categories: timeout, http_status, transport, not_delivered, connection_drop, etc.).
- **Deterministic burst / zone events** (default on) with CLI and config knobs.
- Backend and reporter wiring; `cargo test -p arcane-swarm` passes.

**Companion PR (merge first or coordinate):** [arcane_swarm PR #1](https://github.com/brainy-bots/arcane_swarm/pull/1) (`feature/error-taxonomy-instrumentation` → `master`). This benchmark PR points the submodule at the tip of that branch.

### Benchmark repo / harness

- **`Run-Benchmark.ps1`:** `-ConfigFile` JSON merge (strict key allowlist); passes burst flags to swarm; **`BenchmarkHarnessHelpers.ps1`** for config + safe environment path segment.
- **`Run-Benchmark.ps1`:** regex/manifest support for optional `err_json` in swarm `FINAL:` lines.

### AWS

- **`DistributedComponents`:** Redis + SpacetimeDB on separate EC2 instances, driver on a third; private VPC IPs between deps.
- **`AwsBenchmarkEnvironmentRegistry.ps1`:** single routing table for init / remote / remove.
- **`AwsHelpers.ps1`:** `Send-SsmRunShellScript`, `Wait-SsmCommandInvocation`, `Get-Ec2PrivateIp`.
- **`Cleanup-AwsBenchmark.ps1`:** distributed topology **requires `-StatePath`**; no silent no-op teardown.
- **Docs:** `Setup-AwsBenchmark` / `Cleanup-AwsBenchmark` / cloud README / `REPRODUCIBILITY.md` / `results/README.md`.

### Tests

- Pester: harness helpers, `Escape-BashDoubleQuoted` / `Get-AwsCliFileUri`, registry unknown-env throws, distributed cleanup instance-id plan, layout.
- **`Get-AwsBenchmarkKnownEnvironments`** for stable testing.
- Root **README** documents `Invoke-Pester -Path ./tests -CI`.
- `.gitignore`: `testResults.xml`.

### Follow-up (not in this PR)

Multi-host **Arcane** (manager + N clusters on separate machines) and tiered published runs are intentionally deferred to a later PR.

### Checklist

- [ ] Merge **[arcane_swarm PR #1](https://github.com/brainy-bots/arcane_swarm/pull/1)**; update submodule to `master` after merge if needed.
- [ ] CI: Pester + ScriptAnalyzer on Windows.