### PR TITLE
docs: Terraform install instructions (Windows/macOS/Linux)

### DIFF
--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -116,7 +116,7 @@ Compare ceiling lines from the script output or CSVs with **arcane-demos** `docs
 
 ## AWS
 
-Optional flow (three phases, split by tool so every AWS resource is declarative):
+Optional flow (three phases, split by tool so every AWS resource is declarative). **Requires Terraform (>= 1.3)** — see [module install instructions](infra/terraform/aws_benchmark/README.md#install-terraform) (works on Windows, macOS, Linux).
 
 1. **Provision** — `terraform apply` in **`infra/terraform/aws_benchmark/`** creates the EC2 fleet, security group, S3 artifact bucket, IAM role, and instance profile. Pick the topology with **`-var=topology=AwsSpacetimeOnly`** (SpacetimeDB + driver) or **`-var=topology=AwsArcanePerHost`** (Redis + SpacetimeDB + manager + N clusters + driver). Export state for the run phase: `terraform output -json benchmark_state > .benchmark-aws-terraform.json`.
 2. **Run** — **`infra/aws/Run-Benchmark-Aws.ps1 -StatePath .benchmark-aws-terraform.json -ConfigFile <...>`** invokes SSM on the driver to clone the repo, build, run the benchmark, and upload artifacts to S3. **`infra/aws/Collect-AwsBenchmarkResults.ps1`** / **`Sync-AwsBenchmarkResultsFromS3.ps1`** pull results into **`results/runs/<Environment>/<runId>/`** locally.

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -64,7 +64,8 @@ terraform destroy
 
 ## Prerequisites
 
-- AWS CLI configured so `aws sts get-caller-identity` succeeds.
+- **Terraform** — needed for the provision and destroy steps. See [module install instructions](../terraform/aws_benchmark/README.md#install-terraform) (Windows / macOS / Linux).
+- **AWS CLI** configured so `aws sts get-caller-identity` succeeds.
 - Your identity needs `s3:GetObject` (and usually `s3:ListBucket`) on the artifact bucket to download results unless you use `-SkipLocalResultsDownload`.
 - Submodules in this repo point at public GitHub URLs; a token is only needed for private forks (`ARCANE_BENCHMARK_GITHUB_TOKEN` or `-GithubToken`).
 

--- a/infra/terraform/aws_benchmark/README.md
+++ b/infra/terraform/aws_benchmark/README.md
@@ -6,9 +6,22 @@ The PowerShell scripts under `infra/aws/` (`Run-Benchmark-Aws.ps1`, per-topology
 
 ## Prerequisites
 
-- Terraform **>= 1.3**
-- AWS credentials with permissions for EC2, IAM, S3, SSM
+- Terraform **>= 1.3** (cross-platform — Windows, macOS, Linux).
+- AWS credentials with permissions for EC2, IAM, S3, SSM.
 - **`.terraform.lock.hcl`** is committed for reproducible `terraform init`.
+
+### Install Terraform
+
+Pick the one that matches your OS:
+
+| OS | Install |
+|----|---------|
+| **Windows** | `winget install HashiCorp.Terraform` &nbsp;or&nbsp; `choco install terraform` |
+| **macOS** | `brew tap hashicorp/tap && brew install hashicorp/tap/terraform` |
+| **Linux (Debian/Ubuntu)** | `sudo apt-get install -y gnupg software-properties-common` &nbsp;then&nbsp; `curl -fsSL https://apt.releases.hashicorp.com/gpg \| sudo gpg --dearmor -o /usr/share/keyrings/hashicorp-archive-keyring.gpg && echo "deb [signed-by=/usr/share/keyrings/hashicorp-archive-keyring.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" \| sudo tee /etc/apt/sources.list.d/hashicorp.list && sudo apt-get update && sudo apt-get install -y terraform` |
+| **Any OS (no admin)** | Download the binary from <https://developer.hashicorp.com/terraform/install>, extract, and put `terraform` on your `PATH`. |
+
+Verify with `terraform version` — should print `Terraform v1.x`.
 
 ## Validate (no AWS resources touched)
 


### PR DESCRIPTION
## Summary

- Adds per-OS install matrix (winget / choco / brew / apt / raw binary) to `infra/terraform/aws_benchmark/README.md`
- Points `infra/aws/README.md` and `REPRODUCIBILITY.md` at that section so all three entry points have a consistent hand-off
- Answers "how do I install Terraform?" before someone hits the first `terraform apply`

## Test plan

- [ ] Rendered markdown on GitHub reads correctly (table layout, backticks, link target)

🤖 Generated with [Claude Code](https://claude.com/claude-code)