### PR TITLE
fix(arcane): pwsh -Command wrapper + per-key Terraform outputs

### DIFF
--- a/docker/run-benchmark-sweep.sh
+++ b/docker/run-benchmark-sweep.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
-# Driver role. Runs the PowerShell benchmark orchestrator (scripts/Run-Benchmark.ps1)
-# from inside the image against an already-running SpacetimeDB (and optionally
-# Arcane manager/clusters). The orchestrator spawns the arcane-swarm binary that
-# ships in this image — no host toolchain is required.
+# Driver role. Runs the PowerShell benchmark orchestrator
+# (scripts/Run-Benchmark.ps1) from inside the image against an already-running
+# SpacetimeDB (and optionally Arcane manager/clusters). The orchestrator spawns
+# the arcane-swarm binary that ships in this image — no host toolchain is
+# required.
+#
+# The pwsh orchestrator is invoked via `-Command` (not `-File`) so callers can
+# pass full PowerShell syntax in the trailing args — in particular array
+# literals like `-ArcaneClusterHosts '10.0.0.1','10.0.0.2'` needed for
+# multi-host Arcane runs. Use `--` to separate this wrapper's flags from the
+# PowerShell tail.
 #
 # Mount /var/benchmark/out to persist the run folder outside the container:
 #   docker run -v /host/out:/var/benchmark/out IMG run-benchmark-sweep \
 #              --config /opt/benchmark/configs/spacetimedb_only.json \
 #              --spacetime-host http://<spacetime-vpc-ip>:3000 \
-#              --environment AwsSpacetimeOnly
+#              --environment AwsSpacetimeOnly \
+#              -- '-FindArcaneCeiling:$false'
 
 set -euo pipefail
 
@@ -39,15 +47,21 @@ fi
 OUT_DIR="/var/benchmark/out"
 mkdir -p "$OUT_DIR"
 
-# arcane-swarm is on PATH inside this image; Run-Benchmark.ps1 picks it up.
 export PATH="/usr/local/bin:${PATH}"
 
-pwsh -NoProfile -File /opt/benchmark/scripts/Run-Benchmark.ps1 \
-  -ConfigFile "$CONFIG" \
-  -SpacetimeHost "$SPACETIME_HOST" \
-  -Environment "$ENVIRONMENT" \
-  -OutDir "$OUT_DIR" \
-  -SwarmExe /usr/local/bin/arcane-swarm \
-  -ArcaneManagerExe /usr/local/bin/arcane-manager \
-  -ArcaneClusterExe /usr/local/bin/benchmark-cluster \
-  "${EXTRA[@]:-}"
+# Build a PowerShell command string: the baseline flags with values single-
+# quoted for pwsh, then the verbatim EXTRA tail. EXTRA is already PS syntax as
+# the caller wrote it (e.g. -ArcaneClusterHosts '10.0.0.1','10.0.0.2').
+cmd="& '/opt/benchmark/scripts/Run-Benchmark.ps1'"
+cmd+=" -ConfigFile '$CONFIG'"
+cmd+=" -SpacetimeHost '$SPACETIME_HOST'"
+cmd+=" -Environment '$ENVIRONMENT'"
+cmd+=" -OutDir '$OUT_DIR'"
+cmd+=" -SwarmExe '/usr/local/bin/arcane-swarm'"
+cmd+=" -ArcaneManagerExe '/usr/local/bin/arcane-manager'"
+cmd+=" -ArcaneClusterExe '/usr/local/bin/benchmark-cluster'"
+if [ ${#EXTRA[@]} -gt 0 ]; then
+  cmd+=" ${EXTRA[*]}"
+fi
+
+exec pwsh -NoProfile -Command "$cmd"

--- a/infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1
+++ b/infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1
@@ -170,11 +170,10 @@ echo "ERROR: cluster WS not listening on 8090"; docker logs arcane-bench-cluster
   }
 
   # ── 5. Driver — image + run-benchmark-sweep + aws s3 sync ─────────────────
-  # Emit each hostname as its own -ArcaneClusterHosts arg. PowerShell -File mode
-  # accumulates repeated parameter values into the [string[]] binding. Comma-
-  # joined or space-joined single-argv forms are unreliable here (PS does not
-  # auto-split a single argv) so we do the loop explicitly.
-  $pwshClusterHostsArg = ($clusterIps | ForEach-Object { "-ArcaneClusterHosts $_" }) -join ' '
+  # run-benchmark-sweep invokes pwsh with -Command, so the tail is parsed as
+  # PowerShell. Emit a PS array literal for -ArcaneClusterHosts.
+  $achInner = ($clusterIps | ForEach-Object { "'$_'" }) -join ','
+  $pwshClusterHostsArg = "-ArcaneClusterHosts $achInner"
 
   $drvTpl = @'
 #!/bin/bash

--- a/infra/terraform/aws_benchmark/outputs.tf
+++ b/infra/terraform/aws_benchmark/outputs.tf
@@ -13,17 +13,18 @@ locals {
     RemoteProvisionProfile   = var.remote_provision_profile
   }
 
-  bench_state_topology = local.is_stonly ? {
-    SpacetimeInstanceId = aws_instance.stonly_spacetime[0].id
-    BenchmarkInstanceId = aws_instance.stonly_driver[0].id
-    } : {
-    RedisInstanceId     = aws_instance.arph_redis[0].id
-    SpacetimeInstanceId = aws_instance.arph_spacetime[0].id
-    ManagerInstanceId   = aws_instance.arph_manager[0].id
-    ClusterInstanceIds  = [for i in aws_instance.arph_cluster : i.id]
-    ClusterIds          = [for u in random_uuid.cluster : u.result]
-    MaxArcaneClusters   = var.arcane_cluster_count
-    BenchmarkInstanceId = aws_instance.arph_driver[0].id
+  # Per-key dispatch. Keeping the object shape constant across topologies lets
+  # Terraform unify types (each key becomes nullable-string / nullable-list).
+  # The empty-tuple indexing is guarded by try() because the inactive side
+  # references an empty aws_instance.* tuple whose [0] has no type.
+  bench_state_topology = {
+    SpacetimeInstanceId = local.is_stonly ? try(aws_instance.stonly_spacetime[0].id, null) : try(aws_instance.arph_spacetime[0].id, null)
+    BenchmarkInstanceId = local.is_stonly ? try(aws_instance.stonly_driver[0].id, null) : try(aws_instance.arph_driver[0].id, null)
+    RedisInstanceId     = local.is_arph ? try(aws_instance.arph_redis[0].id, null) : null
+    ManagerInstanceId   = local.is_arph ? try(aws_instance.arph_manager[0].id, null) : null
+    ClusterInstanceIds  = local.is_arph ? [for i in aws_instance.arph_cluster : i.id] : []
+    ClusterIds          = local.is_arph ? [for u in random_uuid.cluster : u.result] : []
+    MaxArcaneClusters   = local.is_arph ? var.arcane_cluster_count : 0
   }
 }
 
@@ -34,7 +35,7 @@ output "benchmark_state" {
 
 output "driver_instance_id" {
   description = "EC2 id of the benchmark driver (SSM target)."
-  value       = local.is_stonly ? aws_instance.stonly_driver[0].id : aws_instance.arph_driver[0].id
+  value       = local.is_stonly ? try(aws_instance.stonly_driver[0].id, null) : try(aws_instance.arph_driver[0].id, null)
 }
 
 output "security_group_id" {


### PR DESCRIPTION
## Summary

Three fixes that unblock AwsArcanePerHost end-to-end, validated locally via `docker compose`-style stack:

1. **`docker/run-benchmark-sweep.sh`**: use `pwsh -Command` instead of `-File`. `-File` mode cannot accept PS array literals — it binds the comma-joined string as a single element. `-Command` parses PS syntax in the tail so multi-host Arcane sweeps bind correctly.
2. **`infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1`**: emit `-ArcaneClusterHosts` as a PS array literal (`'ip1','ip2'`). Now parsed correctly by the `-Command` wrapper.
3. **`infra/terraform/aws_benchmark/outputs.tf`**: flatten the `is_stonly ? {…stonly…} : {…arph…}` ternary into per-key conditionals. The old object-valued form tried to unify two different shapes and blew up with `attribute types must all match for conversion to map` on AwsArcanePerHost apply.

## Verified

Ran a full local Arcane sweep (Redis + SpacetimeDB + manager + 2 benchmark-cluster + driver) against the new image — sweep ran through every tier 1500→6000 and wrote CSV + manifest to the mounted volume without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)