### PR TITLE
fix(harness): wait for Arcane ramp before starting tier measurement

### DIFF
--- a/scripts/BenchmarkHarnessHelpers.ps1
+++ b/scripts/BenchmarkHarnessHelpers.ps1
@@ -37,6 +37,69 @@ function Get-ArcaneClustersEntitiesTotal {
   return $sum
 }
 
+# Poll each cluster's /stats until the total entity count reaches a target
+# ratio of the expected player count, or until timeout. This is the "ramp
+# completed" signal before starting the measurement window — at scale
+# (1500+ players) the swarm takes 30-60s to fully connect on AWS, which is
+# longer than the tier's DurationSeconds. Starting the measurement mid-ramp
+# produces meaningless numbers.
+#
+# Uses per-host base port + (index * stride) so it matches the cluster layout
+# used elsewhere (stride 1 for local, stride 0 for AwsArcanePerHost).
+#
+# Returns a hashtable:
+#   @{ Ready = $bool; FinalTotal = int; ElapsedSec = double; Detail = string }
+function Wait-ArcaneClustersReachEntityCount {
+  param(
+    [Parameter(Mandatory)][string[]]$ClusterHosts,
+    [int]$ClusterBasePort = 8090,
+    [int]$ClusterPortStride = 1,
+    [Parameter(Mandatory)][int]$TargetTotalEntities,
+    [double]$ReachedRatioMin = 0.95,
+    [int]$TimeoutSeconds = 180,
+    [int]$PollIntervalSeconds = 2
+  )
+  $required = [int][Math]::Ceiling($TargetTotalEntities * $ReachedRatioMin)
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  $started = Get-Date
+  $lastTotal = -1
+  $lastDetail = ''
+  while ((Get-Date) -lt $deadline) {
+    $total = 0
+    $pollOk = $true
+    $detail = @()
+    for ($i = 0; $i -lt $ClusterHosts.Count; $i++) {
+      $h = $ClusterHosts[$i]
+      $statsPort = $ClusterBasePort + ($i * $ClusterPortStride) + 1
+      $json = Get-ArcaneClusterStatsJson -ClusterHost $h -ClusterStatsPort $statsPort -TimeoutSec 5
+      if ($null -eq $json) {
+        $pollOk = $false
+        $detail += "cluster[$i] $h`:$statsPort UNREACHABLE"
+      } else {
+        $total += [int]$json.entities_current
+        $detail += "cluster[$i] $h`:$statsPort entities=$($json.entities_current) msgs_ps=$($json.msgs_player_state)"
+      }
+    }
+    $lastTotal = $total
+    $lastDetail = $detail -join '; '
+    if ($pollOk -and $total -ge $required) {
+      return @{
+        Ready      = $true
+        FinalTotal = $total
+        ElapsedSec = ((Get-Date) - $started).TotalSeconds
+        Detail     = $lastDetail
+      }
+    }
+    Start-Sleep -Seconds $PollIntervalSeconds
+  }
+  return @{
+    Ready      = $false
+    FinalTotal = $lastTotal
+    ElapsedSec = ((Get-Date) - $started).TotalSeconds
+    Detail     = "ramp timed out after ${TimeoutSeconds}s: reached $lastTotal / $required required (target $TargetTotalEntities). $lastDetail"
+  }
+}
+
 function Test-IsLocalLoopbackHostName([string]$TargetHost) {
   if ([string]::IsNullOrWhiteSpace($TargetHost)) { return $true }
   $x = $TargetHost.Trim().ToLowerInvariant()

--- a/scripts/Run-Benchmark.ps1
+++ b/scripts/Run-Benchmark.ps1
@@ -86,7 +86,14 @@ param(
   # Minimum fraction of the player tier the clusters must have observed for the
   # tier to count as valid. The swarm may be slightly ahead of the cluster's
   # entity map at the moment we poll, so we don't require 100%.
-  [double] $ArcaneEntityObservedRatioMin = 0.5
+  [double] $ArcaneEntityObservedRatioMin = 0.5,
+  # Ramp-up tuning. At scale (1500+ players on AWS) tokio-tungstenite takes
+  # tens of seconds to open every WebSocket; if we start the measurement window
+  # before the swarm finishes connecting, the "failing" tier is really the ramp
+  # being caught mid-flight. Wait up to this many seconds for >= RampReachedRatio
+  # of players to show up at the cluster's /stats before calling RESET.
+  [int] $ArcaneRampTimeoutSeconds = 180,
+  [double] $ArcaneRampReachedRatio = 0.95
 )
 
 $ErrorActionPreference = 'Stop'
@@ -792,7 +799,36 @@ function Run-Scenario-Arcane {
     while ($players -le $ScenarioMaxPlayers) {
       Write-Host "  [Arcane+Spacetime] num_servers=$NumServers testing players=$players ..." -ForegroundColor Gray
       Send-SwarmCommand -Port $ControlPort -Line "SET_PLAYERS $players"
-      Start-Sleep -Seconds 2
+
+      # Wait for the swarm's connects to reach the cluster's /stats before we
+      # start the measurement window. Starting RESET mid-ramp produces numbers
+      # that are dominated by the cluster's still-empty minutes, not steady
+      # state. If ramp times out (cluster genuinely can't accept the connects
+      # in time), this tier is marked INVALID and the sweep stops.
+      $clusterHostsForRamp = @()
+      for ($i = 0; $i -lt $NumServers; $i++) {
+        $clusterHostsForRamp += if ($ArcaneClusterHosts.Count -eq 0) { '127.0.0.1' } else { $ArcaneClusterHosts[$i] }
+      }
+      $ramp = Wait-ArcaneClustersReachEntityCount -ClusterHosts $clusterHostsForRamp `
+        -ClusterBasePort $ArcaneClusterBasePort -ClusterPortStride $ArcaneClusterPortStride `
+        -TargetTotalEntities $players -ReachedRatioMin $ArcaneRampReachedRatio `
+        -TimeoutSeconds $ArcaneRampTimeoutSeconds -PollIntervalSeconds 2
+      Write-Host ("    [ramp] reached={0} target~{1} elapsed={2:N1}s ready={3}" `
+          -f $ramp.FinalTotal, $players, $ramp.ElapsedSec, $ramp.Ready) -ForegroundColor DarkGray
+      if (-not $ramp.Ready) {
+        Write-Host ("    [invalid] tier players=$players RAMP FAILED: $($ramp.Detail)") -ForegroundColor Yellow
+        $script:ArcaneRunEvidence += [PSCustomObject]@{
+          num_servers               = $NumServers
+          players                   = $players
+          swarm_pass                = $false
+          cluster_entities_observed = $ramp.FinalTotal
+          cluster_entities_required = [int][Math]::Ceiling($players * $ArcaneRampReachedRatio)
+          tier_valid                = $false
+          validity_reason           = "ramp timeout: $($ramp.Detail)"
+        }
+        break
+      }
+
       Send-SwarmCommand -Port $ControlPort -Line 'RESET'
       Start-Sleep -Seconds $DurationSeconds
       Send-SwarmCommand -Port $ControlPort -Line 'REPORT'


### PR DESCRIPTION
## Summary

Resolves the mystery from the last AwsArcanePerHost investigation. The clusters were never actually collapsing entity_ids — `unique_entity_ids_seen` came back as 750 per cluster after the run, exactly matching the tier. The "only 39 entities" I reported was a polling race: at 1500-player scale on AWS, opening 1500 WebSocket connections takes 30-60s, which is longer than the 30-second tier window. My Phase-1 evidence check fired during the ramp, not after steady state.

## Fix

New helper `Wait-ArcaneClustersReachEntityCount` in `BenchmarkHarnessHelpers.ps1`. After each `SET_PLAYERS`, the Arcane tier loop polls each cluster's `/stats` until `sum(entities_current)` reaches `ArcaneRampReachedRatio × players` (default 0.95) or `ArcaneRampTimeoutSeconds` (default 180) elapses. Only then does it call `RESET` and enter the measurement window. If ramp times out, the tier is marked INVALID with the partial count in the reason, and the sweep stops — that's a real cluster saturation signal, not an artifact.

## Verification

- Local docker stack: 10-player tier ramps in 0.1s, 20-player tier in 2.0s. Evidence check passes; manifest `run_valid: true`.
- Syntax parse-only clean for both scripts.
- Pre-existing post-tier evidence check retained — it still catches the case where a cluster dies during the measurement window.

## Follow-ups (not in this PR)

- After this lands: rebuild image, re-run AwsArcanePerHost. Expect ramp to complete in ~30-60s at 1500 players, then steady-state measurement gives real numbers.
- Remaining task #25 (ack-based RTT) becomes cleaner once we have real ramp-fed steady-state runs to validate against.

🤖 Generated with [Claude Code](https://claude.com/claude-code)