### PR TITLE
feat(arcane-mode): drop per-action HTTP, persist via L1 user_data

### DIFF
--- a/crates/benchmark-cluster/Cargo.lock
+++ b/crates/benchmark-cluster/Cargo.lock
@@ -92,7 +92,6 @@ version = "0.1.0"
 dependencies = [
  "arcane-core",
  "arcane-infra",
- "reqwest",
  "serde_json",
  "uuid",
 ]

--- a/crates/benchmark-cluster/Cargo.toml
+++ b/crates/benchmark-cluster/Cargo.toml
@@ -13,4 +13,3 @@ arcane-core = { path = "../../arcane/crates/arcane-core" }
 arcane-infra = { path = "../../arcane/crates/arcane-infra", features = ["cluster-ws", "spacetimedb-persist"] }
 uuid = { version = "1.0", features = ["v4"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["blocking", "json"] }

--- a/crates/benchmark-cluster/src/main.rs
+++ b/crates/benchmark-cluster/src/main.rs
@@ -10,13 +10,17 @@
 //!   REDIS_URL             — optional; default `redis://127.0.0.1:6379`.
 //!   NEIGHBOR_IDS          — optional; comma-separated UUIDs of neighbor clusters.
 //!   CLUSTER_WS_PORT       — optional; default 8080.
-//!   SPACETIMEDB_URI       — optional; default `http://127.0.0.1:3000`.
-//!   SPACETIMEDB_DATABASE  — optional; default `arcane`.
 //!
-//! Persistence (set by Run-Benchmark.ps1 or Docker):
+//! Persistence (read by `arcane_infra::spacetimedb_persist`; set by Run-Benchmark.ps1 or Docker):
+//!   SPACETIMEDB_URI          — SpacetimeDB HTTP endpoint (default `http://127.0.0.1:3000`).
+//!   SPACETIMEDB_DATABASE     — SpacetimeDB database name (default `arcane`).
 //!   SPACETIMEDB_PERSIST      — "1" or "true" to enable (default: disabled).
 //!   SPACETIMEDB_PERSIST_HZ   — persist frequency (default: 1).
 //!   SPACETIMEDB_PERSIST_BATCH_SIZE — entities per HTTP request (default: 0 = unlimited).
+//!
+//! The simulation itself does not talk to SpacetimeDB. Per-entity game state (HP,
+//! inventory, buffs) lives in cluster-local memory and rides on `entity.user_data`
+//! through the Arcane L1 auto-persist path.
 
 mod simulation;
 
@@ -51,12 +55,7 @@ fn main() -> Result<(), String> {
         .and_then(|s| s.parse().ok())
         .unwrap_or(8080);
 
-    let spacetimedb_url =
-        env::var("SPACETIMEDB_URI").unwrap_or_else(|_| "http://127.0.0.1:3000".to_string());
-    let database =
-        env::var("SPACETIMEDB_DATABASE").unwrap_or_else(|_| "arcane".to_string());
-
-    let sim = BenchmarkSimulation::new(spacetimedb_url, database);
+    let sim = BenchmarkSimulation::new();
 
     eprintln!(
         "benchmark-cluster: physics=kinematic collision_radius={} buff_duration={}ticks",

--- a/crates/benchmark-cluster/src/simulation.rs
+++ b/crates/benchmark-cluster/src/simulation.rs
@@ -1,20 +1,32 @@
-//! Benchmark simulation — implements ClusterSimulation with kinematic physics.
+//! Benchmark simulation — implements `ClusterSimulation` with kinematic physics.
+//!
+//! ## Progressive-API level-1 persistence
+//!
+//! Per-entity game state (HP, inventory, active buff, interaction counter) lives in
+//! cluster-local memory and rides along with the Arcane L1 auto-persist path — the cluster
+//! mutates each entity's `user_data` JSON at the end of every tick and the throttled
+//! `set_entities` snapshot flushes it into SpacetimeDB at 1 Hz. No per-action reducer calls,
+//! no HTTP client, no blocking the tick loop on SpacetimeDB round-trips.
+//!
+//! Before this module climbed to L1, every damage/use/pickup/interact event fired a blocking
+//! `reqwest::blocking` POST inside `on_tick`, stalling the tick loop and producing silently
+//! invalid benchmark numbers (entities=0 observed server-side under load).
 //!
 //! ## Fairness contract
 //!
 //! The physics constants and operations here MUST match the SpacetimeDB-only module's
 //! `physics_tick` reducer exactly. If you change a value here, change it in
-//! `crates/benchmark-spacetimedb-full/src/lib.rs` too.
-//!
-//! The collision detection algorithm is identical: O(n^2) pairwise distance check.
-//! This is intentionally expensive — it's the work that Arcane distributes across clusters.
+//! `crates/benchmark-spacetimedb-full/src/lib.rs` too. The collision detection algorithm is
+//! identical: O(n²) pairwise distance check. This is intentionally expensive — it's the work
+//! that Arcane distributes across clusters.
 
 use std::collections::HashMap;
+use std::sync::Mutex;
 
 use arcane_core::cluster_simulation::{ClusterSimulation, ClusterTickContext};
 use uuid::Uuid;
 
-// ── Physics constants (MUST match benchmark-spacetimedb-full) ───────��───────
+// ── Physics constants (MUST match benchmark-spacetimedb-full) ────────────────
 pub const WORLD_SIZE: f64 = 5000.0;
 #[allow(dead_code)] // Documented for equivalence with SpacetimeDB physics_tick
 pub const PHYSICS_SPEED: f64 = 600.0;
@@ -26,125 +38,96 @@ pub const COLLISION_RADIUS: f64 = 50.0;
 pub const COLLISION_DAMAGE: u32 = 10;
 pub const BUFF_SPEED_MULTIPLIER: f64 = 2.0;
 pub const BUFF_DURATION_TICKS: u64 = 200; // 10 seconds at 20 Hz
+pub const INITIAL_HP: u32 = 100;
+const SPEED_POTION_ITEM: u32 = 0;
 
-/// Per-entity buff state tracked by the cluster (not persisted — ephemeral).
+#[derive(Default, Clone)]
 struct BuffState {
     speed_multiplier: f64,
     expires_at_tick: u64,
 }
 
-/// Benchmark simulation implementing kinematic physics, collision detection,
-/// buff application, and SpacetimeDB integration for game actions.
+/// Per-entity game state held cluster-local. Snapshotted into `entity.user_data` at the end
+/// of every tick so the L1 auto-persist path (1 Hz `set_entities`) carries it to SpacetimeDB.
+#[derive(Default, Clone)]
+struct GameState {
+    hp: u32,
+    /// item_type → quantity.
+    inventory: HashMap<u32, u32>,
+    buff: Option<BuffState>,
+    /// Lifetime count of `interact` actions originated by this entity. Cheap to carry; gives
+    /// the benchmark a non-trivial per-entity field that changes over time.
+    interaction_count: u32,
+}
+
+impl GameState {
+    fn fresh() -> Self {
+        Self {
+            hp: INITIAL_HP,
+            ..Self::default()
+        }
+    }
+
+    fn to_user_data(&self, tick: u64) -> serde_json::Value {
+        let inv: serde_json::Map<String, serde_json::Value> = self
+            .inventory
+            .iter()
+            .map(|(k, v)| (k.to_string(), serde_json::Value::from(*v)))
+            .collect();
+        let buff = self
+            .buff
+            .as_ref()
+            .filter(|b| b.expires_at_tick > tick)
+            .map(|b| {
+                serde_json::json!({
+                    "mult": b.speed_multiplier,
+                    "expires": b.expires_at_tick,
+                })
+            });
+        serde_json::json!({
+            "hp": self.hp,
+            "inv": serde_json::Value::Object(inv),
+            "buff": buff,
+            "events": self.interaction_count,
+        })
+    }
+}
+
 pub struct BenchmarkSimulation {
-    /// SpacetimeDB HTTP endpoint for reducer calls (e.g. apply_damage, use_item).
-    spacetimedb_url: String,
-    /// SpacetimeDB database name.
-    database: String,
-    /// HTTP client for SpacetimeDB calls.
-    client: reqwest::blocking::Client,
-    /// Active buffs per entity (cluster-local, ephemeral).
-    buffs: std::sync::Mutex<HashMap<Uuid, BuffState>>,
+    /// Per-entity game state (cluster-local authoritative copy).
+    state: Mutex<HashMap<Uuid, GameState>>,
+}
+
+impl Default for BenchmarkSimulation {
+    fn default() -> Self {
+        Self::new()
+    }
 }
 
 impl BenchmarkSimulation {
-    pub fn new(spacetimedb_url: String, database: String) -> Self {
+    pub fn new() -> Self {
         Self {
-            spacetimedb_url,
-            database,
-            client: reqwest::blocking::Client::builder()
-                .timeout(std::time::Duration::from_secs(5))
-                .build()
-                .expect("reqwest client"),
-            buffs: std::sync::Mutex::new(HashMap::new()),
+            state: Mutex::new(HashMap::new()),
         }
-    }
-
-    fn reducer_url(&self, reducer: &str) -> String {
-        format!(
-            "{}/v1/database/{}/call/{}",
-            self.spacetimedb_url, self.database, reducer
-        )
-    }
-
-    fn call_apply_damage_batch(&self, targets: &[(Uuid, u32)]) {
-        if targets.is_empty() {
-            return;
-        }
-        let targets_json: String = targets
-            .iter()
-            .map(|(id, _)| format!("{{\"__uuid__\":{}}}", id.as_u128()))
-            .collect::<Vec<_>>()
-            .join(",");
-        let amounts_json: String = targets
-            .iter()
-            .map(|(_, amount)| amount.to_string())
-            .collect::<Vec<_>>()
-            .join(",");
-        let body = format!("[[{}],[{}]]", targets_json, amounts_json);
-        let _ = self
-            .client
-            .post(&self.reducer_url("apply_damage_batch"))
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send();
-    }
-
-    fn call_use_item(&self, owner_id: Uuid, item_type: u32) -> bool {
-        let body = format!(
-            "[{{\"__uuid__\":{}}},{}]",
-            owner_id.as_u128(),
-            item_type
-        );
-        self.client
-            .post(&self.reducer_url("use_item"))
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send()
-            .map(|r| r.status().is_success())
-            .unwrap_or(false)
-    }
-
-    fn call_pickup_item(&self, owner_id: Uuid, item_type: u32, quantity: u32) {
-        let body = format!(
-            "[{{\"__uuid__\":{}}},{},{}]",
-            owner_id.as_u128(),
-            item_type,
-            quantity
-        );
-        let _ = self
-            .client
-            .post(&self.reducer_url("pickup_item"))
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send();
-    }
-
-    fn call_player_interact(&self, actor_id: Uuid, target_id: Uuid, event_type: u32) {
-        let body = format!(
-            "[{{\"__uuid__\":{}}},{{\"__uuid__\":{}}},{}]",
-            actor_id.as_u128(),
-            target_id.as_u128(),
-            event_type
-        );
-        let _ = self
-            .client
-            .post(&self.reducer_url("player_interact"))
-            .header("Content-Type", "application/json")
-            .body(body)
-            .send();
     }
 }
 
 impl ClusterSimulation for BenchmarkSimulation {
     fn on_tick(&self, ctx: &mut ClusterTickContext<'_>) {
         let tick = ctx.tick;
-        let mut buffs = self.buffs.lock().expect("buffs lock");
+        let mut state = self.state.lock().expect("game state lock");
 
-        // Expire old buffs
-        buffs.retain(|_, b| b.expires_at_tick > tick);
+        // Ensure every live entity has a state row; drop rows for entities no longer present.
+        state.retain(|id, _| ctx.entities.contains_key(id));
+        for id in ctx.entities.keys() {
+            state.entry(*id).or_insert_with(GameState::fresh);
+        }
 
-        // Process game actions from clients
+        // Process game actions from clients (mutate local state; no HTTP).
         for action in ctx.game_actions {
+            let Some(gs) = state.get_mut(&action.entity_id) else {
+                continue;
+            };
             match action.action_type.as_str() {
                 "use_item" => {
                     let item_type = action
@@ -152,18 +135,21 @@ impl ClusterSimulation for BenchmarkSimulation {
                         .get("item_type")
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0) as u32;
-                    // Call SpacetimeDB to validate and consume
-                    if self.call_use_item(action.entity_id, item_type) {
-                        // Item 0 = speed potion: apply buff locally
-                        if item_type == 0 {
-                            buffs.insert(
-                                action.entity_id,
-                                BuffState {
-                                    speed_multiplier: BUFF_SPEED_MULTIPLIER,
-                                    expires_at_tick: tick + BUFF_DURATION_TICKS,
-                                },
-                            );
+                    let consumed = match gs.inventory.get_mut(&item_type) {
+                        Some(q) if *q > 0 => {
+                            *q -= 1;
+                            if *q == 0 {
+                                gs.inventory.remove(&item_type);
+                            }
+                            true
                         }
+                        _ => false,
+                    };
+                    if consumed && item_type == SPEED_POTION_ITEM {
+                        gs.buff = Some(BuffState {
+                            speed_multiplier: BUFF_SPEED_MULTIPLIER,
+                            expires_at_tick: tick + BUFF_DURATION_TICKS,
+                        });
                     }
                 }
                 "pickup_item" => {
@@ -177,70 +163,68 @@ impl ClusterSimulation for BenchmarkSimulation {
                         .get("quantity")
                         .and_then(|v| v.as_u64())
                         .unwrap_or(1) as u32;
-                    self.call_pickup_item(action.entity_id, item_type, quantity);
+                    *gs.inventory.entry(item_type).or_insert(0) += quantity;
                 }
                 "interact" => {
-                    let target_id = action
-                        .payload
-                        .get("target_id")
-                        .and_then(|v| v.as_str())
-                        .and_then(|s| Uuid::parse_str(s).ok())
-                        .unwrap_or(Uuid::nil());
-                    let event_type = action
-                        .payload
-                        .get("event_type")
-                        .and_then(|v| v.as_u64())
-                        .unwrap_or(0) as u32;
-                    self.call_player_interact(action.entity_id, target_id, event_type);
+                    gs.interaction_count = gs.interaction_count.saturating_add(1);
                 }
-                _ => {} // unknown action type — ignore
+                _ => {}
             }
         }
 
-        // Physics: move entities based on velocity.
-        // The swarm sends velocity as pre-computed displacement per tick:
-        //   vx = dir_x * MOVE_SPEED * tick_dt  (see arcane_swarm player.rs)
-        // So we add velocity directly, with buff speed multiplier applied.
-        // In SpacetimeDB-only mode, physics_tick reads raw direction and applies
-        // step = PHYSICS_SPEED * PHYSICS_DT. Here the swarm already did that,
-        // so we just multiply by speed_mult (1.0 if no buff).
+        // Physics: the swarm sends velocity as pre-computed per-tick displacement
+        // (dir * PHYSICS_SPEED * PHYSICS_DT), so we add it directly. Speed multiplier
+        // from any active buff applies on top.
         for entity in ctx.entities.values_mut() {
-            let speed_mult = buffs
+            let speed_mult = state
                 .get(&entity.entity_id)
+                .and_then(|gs| gs.buff.as_ref())
+                .filter(|b| b.expires_at_tick > tick)
                 .map(|b| b.speed_multiplier)
                 .unwrap_or(1.0);
 
-            entity.position.x = (entity.position.x + entity.velocity.x * speed_mult).clamp(WORLD_MIN, WORLD_MAX);
-            entity.position.z = (entity.position.z + entity.velocity.z * speed_mult).clamp(WORLD_MIN, WORLD_MAX);
+            entity.position.x =
+                (entity.position.x + entity.velocity.x * speed_mult).clamp(WORLD_MIN, WORLD_MAX);
+            entity.position.z =
+                (entity.position.z + entity.velocity.z * speed_mult).clamp(WORLD_MIN, WORLD_MAX);
         }
 
-        // Collision detection — O(n^2), same as SpacetimeDB-only mode.
-        // Damage is batched into a single SpacetimeDB call per tick to avoid
-        // N² blocking HTTP round-trips (which would unfairly penalize Arcane mode).
-        let entities: Vec<(Uuid, f64, f64)> = ctx
+        // Collision detection — O(n²), same as SpacetimeDB-only mode. Damage goes to local
+        // state; the 1 Hz L1 snapshot carries the resulting HP values into SpacetimeDB.
+        let ids_pos: Vec<(Uuid, f64, f64)> = ctx
             .entities
             .values()
             .map(|e| (e.entity_id, e.position.x, e.position.z))
             .collect();
         let radius_sq = COLLISION_RADIUS * COLLISION_RADIUS;
-        let mut damage_batch: Vec<(Uuid, u32)> = Vec::new();
-        for i in 0..entities.len() {
-            for j in (i + 1)..entities.len() {
-                let dx = entities[i].1 - entities[j].1;
-                let dz = entities[i].2 - entities[j].2;
+        for i in 0..ids_pos.len() {
+            for j in (i + 1)..ids_pos.len() {
+                let dx = ids_pos[i].1 - ids_pos[j].1;
+                let dz = ids_pos[i].2 - ids_pos[j].2;
                 if dx * dx + dz * dz < radius_sq {
-                    damage_batch.push((entities[i].0, COLLISION_DAMAGE));
-                    damage_batch.push((entities[j].0, COLLISION_DAMAGE));
+                    if let Some(gs) = state.get_mut(&ids_pos[i].0) {
+                        gs.hp = gs.hp.saturating_sub(COLLISION_DAMAGE);
+                    }
+                    if let Some(gs) = state.get_mut(&ids_pos[j].0) {
+                        gs.hp = gs.hp.saturating_sub(COLLISION_DAMAGE);
+                    }
                 }
             }
         }
-        self.call_apply_damage_batch(&damage_batch);
+
+        // Sync local state into entity.user_data so the L1 auto-persist snapshot carries it.
+        for (id, entity) in ctx.entities.iter_mut() {
+            if let Some(gs) = state.get(id) {
+                entity.user_data = gs.to_user_data(tick);
+            }
+        }
     }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use arcane_core::cluster_simulation::GameAction;
     use arcane_core::replication_channel::EntityStateEntry;
     use arcane_core::Vec3;
 
@@ -253,58 +237,162 @@ mod tests {
         )
     }
 
+    fn run_tick(
+        sim: &BenchmarkSimulation,
+        tick: u64,
+        entities: &mut HashMap<Uuid, EntityStateEntry>,
+        actions: &[GameAction],
+    ) {
+        let mut pending_removals: Vec<Uuid> = Vec::new();
+        let mut ctx = ClusterTickContext {
+            cluster_id: Uuid::nil(),
+            tick,
+            dt_seconds: 0.05,
+            entities,
+            pending_removals: &mut pending_removals,
+            game_actions: actions,
+        };
+        sim.on_tick(&mut ctx);
+    }
+
     #[test]
     fn physics_adds_velocity_directly_with_clamp() {
-        // Swarm sends velocity as pre-computed displacement: dir * MOVE_SPEED * tick_dt
-        // For dir_x=1.0: vx = 1.0 * 600 * 0.05 = 30.0
+        // Swarm sends velocity as displacement (dir * PHYSICS_SPEED * PHYSICS_DT = 30 for dir=1).
+        let sim = BenchmarkSimulation::new();
         let mut entities = HashMap::new();
         entities.insert(Uuid::from_u128(1), mk_entity(1, 2500.0, 2500.0, 30.0, 0.0));
 
-        // Cluster adds velocity directly (no re-multiplication by step)
-        for entity in entities.values_mut() {
-            entity.position.x = (entity.position.x + entity.velocity.x).clamp(WORLD_MIN, WORLD_MAX);
-            entity.position.z = (entity.position.z + entity.velocity.z).clamp(WORLD_MIN, WORLD_MAX);
-        }
+        run_tick(&sim, 1, &mut entities, &[]);
 
         let ent = entities.get(&Uuid::from_u128(1)).unwrap();
-        assert!((ent.position.x - 2530.0).abs() < 0.001, "x should be 2500 + 30 = 2530");
-        assert!((ent.position.z - 2500.0).abs() < 0.001, "z unchanged");
+        assert!((ent.position.x - 2530.0).abs() < 0.001);
+        assert!((ent.position.z - 2500.0).abs() < 0.001);
     }
 
     #[test]
     fn physics_clamps_to_world_bounds() {
+        let sim = BenchmarkSimulation::new();
         let mut entities = HashMap::new();
-        // vx = 30 (one tick displacement), position near max
-        entities.insert(Uuid::from_u128(1), mk_entity(1, WORLD_MAX - 10.0, 2500.0, 30.0, 0.0));
-
-        for entity in entities.values_mut() {
-            entity.position.x = (entity.position.x + entity.velocity.x).clamp(WORLD_MIN, WORLD_MAX);
-        }
-
+        entities.insert(
+            Uuid::from_u128(1),
+            mk_entity(1, WORLD_MAX - 10.0, 2500.0, 30.0, 0.0),
+        );
+        run_tick(&sim, 1, &mut entities, &[]);
         let ent = entities.get(&Uuid::from_u128(1)).unwrap();
-        assert_eq!(ent.position.x, WORLD_MAX, "should clamp to WORLD_MAX");
+        assert_eq!(ent.position.x, WORLD_MAX);
     }
 
     #[test]
-    fn collision_detection_finds_nearby_entities() {
-        let entities: Vec<(Uuid, f64, f64)> = vec![
-            (Uuid::from_u128(1), 100.0, 100.0),
-            (Uuid::from_u128(2), 130.0, 100.0), // 30 units away — within COLLISION_RADIUS (50)
-            (Uuid::from_u128(3), 500.0, 500.0), // far away
+    fn collision_drops_hp_locally_without_network() {
+        let sim = BenchmarkSimulation::new();
+        let mut entities = HashMap::new();
+        // Two entities 30 units apart — inside COLLISION_RADIUS (50).
+        entities.insert(Uuid::from_u128(1), mk_entity(1, 100.0, 100.0, 0.0, 0.0));
+        entities.insert(Uuid::from_u128(2), mk_entity(2, 130.0, 100.0, 0.0, 0.0));
+
+        run_tick(&sim, 1, &mut entities, &[]);
+
+        let e1 = entities.get(&Uuid::from_u128(1)).unwrap();
+        let ud = &e1.user_data;
+        assert_eq!(
+            ud["hp"].as_u64().unwrap(),
+            (INITIAL_HP - COLLISION_DAMAGE) as u64
+        );
+    }
+
+    #[test]
+    fn pickup_then_use_grants_buff_and_speeds_movement() {
+        let sim = BenchmarkSimulation::new();
+        let id = Uuid::from_u128(1);
+        let mut entities = HashMap::new();
+        entities.insert(id, mk_entity(1, 1000.0, 1000.0, 10.0, 0.0));
+
+        let pickup = GameAction {
+            entity_id: id,
+            action_type: "pickup_item".into(),
+            payload: serde_json::json!({ "item_type": 0, "quantity": 1 }),
+        };
+        let use_it = GameAction {
+            entity_id: id,
+            action_type: "use_item".into(),
+            payload: serde_json::json!({ "item_type": 0 }),
+        };
+
+        // Tick 1: pickup item. No buff yet, velocity multiplier 1.0.
+        run_tick(&sim, 1, &mut entities, &[pickup]);
+        assert_eq!(entities.get(&id).unwrap().position.x, 1010.0);
+
+        // Tick 2: use item — buff takes effect *this same tick* (applied before physics).
+        // Position advances by 10 * 2.0 = 20.
+        run_tick(&sim, 2, &mut entities, &[use_it]);
+        assert_eq!(entities.get(&id).unwrap().position.x, 1030.0);
+    }
+
+    #[test]
+    fn user_data_sync_carries_inventory_and_events() {
+        let sim = BenchmarkSimulation::new();
+        let id = Uuid::from_u128(1);
+        let mut entities = HashMap::new();
+        entities.insert(id, mk_entity(1, 2500.0, 2500.0, 0.0, 0.0));
+
+        let actions = vec![
+            GameAction {
+                entity_id: id,
+                action_type: "pickup_item".into(),
+                payload: serde_json::json!({ "item_type": 5, "quantity": 3 }),
+            },
+            GameAction {
+                entity_id: id,
+                action_type: "interact".into(),
+                payload: serde_json::json!({}),
+            },
         ];
-        let radius_sq = COLLISION_RADIUS * COLLISION_RADIUS;
-        let mut collisions = Vec::new();
-        for i in 0..entities.len() {
-            for j in (i + 1)..entities.len() {
-                let dx = entities[i].1 - entities[j].1;
-                let dz = entities[i].2 - entities[j].2;
-                if dx * dx + dz * dz < radius_sq {
-                    collisions.push((entities[i].0, entities[j].0));
-                }
-            }
-        }
-        assert_eq!(collisions.len(), 1);
-        assert_eq!(collisions[0].0, Uuid::from_u128(1));
-        assert_eq!(collisions[0].1, Uuid::from_u128(2));
+        run_tick(&sim, 1, &mut entities, &actions);
+
+        let ud = &entities.get(&id).unwrap().user_data;
+        assert_eq!(ud["hp"].as_u64().unwrap(), INITIAL_HP as u64);
+        assert_eq!(ud["inv"]["5"].as_u64().unwrap(), 3);
+        assert_eq!(ud["events"].as_u64().unwrap(), 1);
+        assert!(ud["buff"].is_null());
+    }
+
+    #[test]
+    fn buff_expires_and_clears_from_user_data() {
+        let sim = BenchmarkSimulation::new();
+        let id = Uuid::from_u128(1);
+        let mut entities = HashMap::new();
+        entities.insert(id, mk_entity(1, 2500.0, 2500.0, 0.0, 0.0));
+
+        let pickup = GameAction {
+            entity_id: id,
+            action_type: "pickup_item".into(),
+            payload: serde_json::json!({ "item_type": 0, "quantity": 1 }),
+        };
+        let use_it = GameAction {
+            entity_id: id,
+            action_type: "use_item".into(),
+            payload: serde_json::json!({ "item_type": 0 }),
+        };
+        run_tick(&sim, 1, &mut entities, &[pickup]);
+        run_tick(&sim, 2, &mut entities, &[use_it]);
+        assert!(!entities.get(&id).unwrap().user_data["buff"].is_null());
+
+        // Advance past expiration.
+        run_tick(&sim, 2 + BUFF_DURATION_TICKS + 1, &mut entities, &[]);
+        assert!(entities.get(&id).unwrap().user_data["buff"].is_null());
+    }
+
+    #[test]
+    fn state_row_is_reclaimed_when_entity_leaves() {
+        let sim = BenchmarkSimulation::new();
+        let id = Uuid::from_u128(1);
+        let mut entities = HashMap::new();
+        entities.insert(id, mk_entity(1, 2500.0, 2500.0, 0.0, 0.0));
+        run_tick(&sim, 1, &mut entities, &[]);
+        assert!(sim.state.lock().unwrap().contains_key(&id));
+
+        entities.clear();
+        run_tick(&sim, 2, &mut entities, &[]);
+        assert!(sim.state.lock().unwrap().is_empty());
     }
 }

--- a/crates/benchmark-spacetimedb-persist/src/lib.rs
+++ b/crates/benchmark-spacetimedb-persist/src/lib.rs
@@ -1,26 +1,36 @@
 //! SpacetimeDB module for **Arcane + SpacetimeDB** benchmark mode.
 //!
-//! In this mode Arcane clusters handle physics simulation and collision detection.
-//! This module provides:
-//! - Entity position persistence (clusters write at 1 Hz via `set_entities`)
-//! - Inventory management (use_item validates and grants buffs)
-//! - Interaction/event logging
-//! - Damage application (clusters call `apply_damage` on collision)
-//! - Health tracking
+//! In this mode Arcane clusters own all simulation and game state. SpacetimeDB acts as the
+//! throttled durable sink for the cluster's per-tick snapshot.
 //!
-//! There is NO `physics_tick`, NO `update_player_input`, NO `PlayerInput` table.
-//! The cluster owns movement. SpacetimeDB owns durable state.
+//! ## Why the module is minimal
 //!
-//! ## Buff response pattern
+//! Earlier revisions of this module exposed per-action reducers (`apply_damage`,
+//! `use_item`, `pickup_item`, `player_interact`) that the cluster called inline during
+//! `on_tick`. That pattern turned the tick loop into a synchronous HTTP driver — the
+//! cluster blocked on SpacetimeDB round-trips thousands of times per second under load.
 //!
-//! When a client sends "use_item" through the cluster, the cluster calls the
-//! `use_item` reducer here. The reducer consumes the item and writes to `active_buff`.
-//! The cluster reads the result (success = buff granted) and applies the speed
-//! multiplier in its simulation. This is the "Client → Cluster → SpacetimeDB" pattern.
+//! The progressive-API level-1 persistence path (see
+//! `arcane/docs/architecture/progressive-api.md`) solves this: the cluster keeps HP,
+//! inventory, buffs, and interaction counters in local memory, writes them to each
+//! entity's `user_data` JSON field, and the `set_entities` snapshot carries the whole
+//! picture to SpacetimeDB at 1 Hz. No per-action reducers needed on the cluster hot path.
+//!
+//! What this module exposes, therefore, is just the persistence sink:
+//! - `Entity` table with `{ entity_id, x, y, z, user_data: String }`.
+//! - `set_entities` reducer: clusters invoke this at 1 Hz to replace the table with the
+//!   current snapshot.
+//!
+//! Game-logic reducers (validation, anti-cheat, shop purchases) would land at ladder
+//! level 2+ when a concrete game demands them — none does today for the benchmark.
 
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
 // ── Entity table (public: clients subscribe, clusters write at 1 Hz) ────────
+//
+// `user_data` is a JSON-encoded string populated by the cluster. The column is opaque to
+// this module by design — the cluster owns the schema. Games that don't mutate `user_data`
+// get an empty string.
 
 #[table(accessor = entity, public)]
 pub struct Entity {
@@ -29,65 +39,17 @@ pub struct Entity {
     pub x: f64,
     pub y: f64,
     pub z: f64,
+    pub user_data: String,
 }
 
-// ── Health table (public: clients see HP) ───────────────────────────────────
-
-#[table(accessor = health, public)]
-pub struct Health {
-    #[primary_key]
-    pub entity_id: spacetimedb::Uuid,
-    pub hp: u32,
-    pub max_hp: u32,
-}
-
-// ── Buff table (cluster reads after use_item call) ──────────────────────────
-
-#[table(accessor = active_buff, public)]
-pub struct ActiveBuff {
-    #[primary_key]
-    pub entity_id: spacetimedb::Uuid,
-    /// Speed multiplier (1.0 = normal, 2.0 = double speed).
-    pub speed_multiplier: f64,
-    /// Duration in ticks (cluster tracks expiration locally).
-    pub duration_ticks: u64,
-}
-
-// ── Inventory table ─────────────────────────────────────────────────────────
-
-#[table(accessor = inventory, public,
-    index(accessor = owner_item, btree(columns = [owner_id, item_type])),
-)]
-pub struct Inventory {
-    #[primary_key]
-    #[auto_inc]
-    pub row_id: u64,
-    pub owner_id: spacetimedb::Uuid,
-    pub item_type: u32,
-    pub quantity: u32,
-}
-
-// ── GameEvent table ─────────────────────────────────────────────────────────
-
-#[table(accessor = game_event, public)]
-pub struct GameEvent {
-    #[primary_key]
-    #[auto_inc]
-    pub event_id: u64,
-    pub actor_id: spacetimedb::Uuid,
-    pub target_id: spacetimedb::Uuid,
-    pub event_type: u32,
-    pub timestamp_us: i64,
-}
-
-// ── Init ────────────────────────────────────────────────────────────────────
+// ── Init ─────────────────────────────────────────────────────────────────────
 
 #[reducer(init)]
 pub fn init(_ctx: &ReducerContext) {
-    log::info!("benchmark-spacetimedb-persist module initialized (Arcane mode — no physics)");
+    log::info!("benchmark-spacetimedb-persist initialized (Arcane mode; L1 auto-persist sink)");
 }
 
-// ── Entity persistence (called by Arcane clusters at 1 Hz) ────��─────────────
+// ── Entity persistence (called by Arcane clusters at 1 Hz) ───────────────────
 
 #[reducer]
 pub fn set_entities(ctx: &ReducerContext, entities: Vec<Entity>) -> Result<(), String> {
@@ -97,180 +59,6 @@ pub fn set_entities(ctx: &ReducerContext, entities: Vec<Entity>) -> Result<(), S
     }
     for e in entities {
         ctx.db.entity().insert(e);
-    }
-    Ok(())
-}
-
-/// Register a new player (called by cluster when a player joins).
-#[reducer]
-pub fn register_player(
-    ctx: &ReducerContext,
-    entity_id: spacetimedb::Uuid,
-    x: f64,
-    y: f64,
-    z: f64,
-) -> Result<(), String> {
-    if ctx.db.entity().entity_id().find(&entity_id).is_none() {
-        ctx.db.entity().insert(Entity {
-            entity_id,
-            x,
-            y,
-            z,
-        });
-    }
-    if ctx.db.health().entity_id().find(&entity_id).is_none() {
-        ctx.db.health().insert(Health {
-            entity_id,
-            hp: 100,
-            max_hp: 100,
-        });
-    }
-    Ok(())
-}
-
-#[reducer]
-pub fn remove_player_by_id(
-    ctx: &ReducerContext,
-    entity_id: spacetimedb::Uuid,
-) -> Result<(), String> {
-    ctx.db.entity().entity_id().delete(&entity_id);
-    ctx.db.health().entity_id().delete(&entity_id);
-    ctx.db.active_buff().entity_id().delete(&entity_id);
-    Ok(())
-}
-
-// ── Inventory reducers ──────────────────────────────────────────────────────
-
-#[reducer]
-pub fn pickup_item(
-    ctx: &ReducerContext,
-    owner_id: spacetimedb::Uuid,
-    item_type: u32,
-    quantity: u32,
-) -> Result<(), String> {
-    let mut found = false;
-    for mut row in ctx.db.inventory().owner_item().filter((owner_id, item_type)) {
-        row.quantity += quantity;
-        ctx.db.inventory().row_id().update(row);
-        found = true;
-        break;
-    }
-    if !found {
-        ctx.db.inventory().insert(Inventory {
-            row_id: 0,
-            owner_id,
-            item_type,
-            quantity,
-        });
-    }
-    Ok(())
-}
-
-/// Use an item. item_type 0 = speed potion (grants 2x speed for 200 ticks / 10 seconds).
-/// The cluster calls this reducer and reads the active_buff table to apply the effect.
-#[reducer]
-pub fn use_item(
-    ctx: &ReducerContext,
-    owner_id: spacetimedb::Uuid,
-    item_type: u32,
-) -> Result<(), String> {
-    let mut consumed = false;
-    for mut row in ctx.db.inventory().owner_item().filter((owner_id, item_type)) {
-        if row.quantity > 1 {
-            row.quantity -= 1;
-            ctx.db.inventory().row_id().update(row);
-        } else {
-            ctx.db.inventory().row_id().delete(&row.row_id);
-        }
-        consumed = true;
-        break;
-    }
-    if !consumed {
-        return Ok(());
-    }
-
-    // Item 0 = speed potion: write buff so cluster can read it
-    if item_type == 0 {
-        if let Some(mut buff) = ctx.db.active_buff().entity_id().find(&owner_id) {
-            buff.speed_multiplier = 2.0;
-            buff.duration_ticks = 200; // 10 seconds at 20 Hz
-            ctx.db.active_buff().entity_id().update(buff);
-        } else {
-            ctx.db.active_buff().insert(ActiveBuff {
-                entity_id: owner_id,
-                speed_multiplier: 2.0,
-                duration_ticks: 200,
-            });
-        }
-    }
-
-    Ok(())
-}
-
-// ── Damage (called by Arcane clusters on collision detection) ────────────────
-
-#[reducer]
-pub fn apply_damage(
-    ctx: &ReducerContext,
-    target_id: spacetimedb::Uuid,
-    amount: u32,
-) -> Result<(), String> {
-    if let Some(mut h) = ctx.db.health().entity_id().find(&target_id) {
-        h.hp = h.hp.saturating_sub(amount);
-        ctx.db.health().entity_id().update(h);
-    }
-    Ok(())
-}
-
-/// Batch damage — cluster sends all collision damage for one tick in a single call.
-/// Each entry is (target_entity_id, damage_amount).
-#[reducer]
-pub fn apply_damage_batch(
-    ctx: &ReducerContext,
-    targets: Vec<spacetimedb::Uuid>,
-    amounts: Vec<u32>,
-) -> Result<(), String> {
-    for (target_id, amount) in targets.into_iter().zip(amounts.into_iter()) {
-        if let Some(mut h) = ctx.db.health().entity_id().find(&target_id) {
-            h.hp = h.hp.saturating_sub(amount);
-            ctx.db.health().entity_id().update(h);
-        }
-    }
-    Ok(())
-}
-
-// ── Interaction / event reducers ────────────────────────────────────────────
-
-#[reducer]
-pub fn player_interact(
-    ctx: &ReducerContext,
-    actor_id: spacetimedb::Uuid,
-    target_id: spacetimedb::Uuid,
-    event_type: u32,
-) -> Result<(), String> {
-    ctx.db.game_event().insert(GameEvent {
-        event_id: 0,
-        actor_id,
-        target_id,
-        event_type,
-        timestamp_us: ctx.timestamp.to_micros_since_unix_epoch(),
-    });
-    Ok(())
-}
-
-#[reducer]
-pub fn cleanup_old_events(ctx: &ReducerContext, max_age_secs: u64) -> Result<(), String> {
-    let cutoff =
-        ctx.timestamp.to_micros_since_unix_epoch() - (max_age_secs as i64 * 1_000_000);
-    let stale: Vec<u64> = ctx
-        .db
-        .game_event()
-        .iter()
-        .filter(|e| e.timestamp_us < cutoff)
-        .map(|e| e.event_id)
-        .collect();
-    for id in stale {
-        ctx.db.game_event().event_id().delete(&id);
     }
     Ok(())
 }


### PR DESCRIPTION
## Summary

Fixes the synchronous-HTTP stall that was making the Arcane-mode benchmark silently measure nothing under load. Moves all per-entity game state into cluster-local memory and rides the [L1 auto-persist path](https://github.com/brainy-bots/arcane/blob/main/docs/architecture/progressive-api.md) (brainy-bots/arcane#23) for durable writes.

## What changed

**`benchmark-cluster` simulation rewrite.** `BenchmarkSimulation` now owns a `HashMap<Uuid, GameState>` with HP, inventory, active buff, and interaction counter. Damage, pickup, use, interact all mutate that map directly. At the end of each tick the state is serialized into `entity.user_data` so arcane's throttled `set_entities` snapshot carries it to SpacetimeDB at 1 Hz. Gone: `reqwest::blocking::Client`, all `call_*` helpers, the `SPACETIMEDB_URI`/`SPACETIMEDB_DATABASE` args on `BenchmarkSimulation::new()`, the `reqwest` dep.

**`benchmark-spacetimedb-persist` module reduced to a sink.** `Entity` table gains `user_data: String`. `Health`, `ActiveBuff`, `Inventory`, `GameEvent` tables and their reducers (`apply_damage`, `apply_damage_batch`, `use_item`, `pickup_item`, `player_interact`, `register_player`, `remove_player_by_id`, `cleanup_old_events`) are deleted — their state now lives in `user_data`. Module reduces to `init` + `set_entities`.

**arcane submodule bumped** to the PR #23 merge (L1 encoder carries `user_data`).

## Why it matters

Before this PR the Arcane-mode cluster was doing what a SpacetimeDB-only app does: a reducer call per player action, inside the tick loop. At 1500 players × ~1 action/sec the tick loop stalled on blocking HTTP and `entities_current` stayed at 0. The run_valid gate (PR #21) was already catching this, but the fix was always going to be architectural: Arcane's whole point is that hot state doesn't round-trip to the DB.

The benchmark fairness claim now holds honestly: SpacetimeDB-only mode still hits reducers per action (that's what it has to do); Arcane mode keeps hot state local and snapshots it. That's the architectural contrast the benchmark is supposed to measure.

## Test plan

- [x] `cargo fmt` / `cargo clippy --tests -D warnings` / `cargo test` on `benchmark-cluster` — 7 tests pass (physics, collision → HP drop, pickup→use→buff applies speed multiplier, buff expires and clears from user_data, user_data carries inventory + events, state rows reclaimed when entities leave)
- [x] `cargo build --target wasm32-unknown-unknown` on `benchmark-spacetimedb-persist` — clean
- [ ] Rebuild Docker image, publish module, smoke-run locally
- [ ] AWS end-to-end at 1500-player tier with `run_valid = true` and non-trivial HP/inv values flowing into SpacetimeDB's `Entity` table

## Schema migration note

Deleting tables (`Health`, `ActiveBuff`, `Inventory`, `GameEvent`) is an incompatible schema change. AWS benchmark runs always provision a fresh SpacetimeDB, so CI is unaffected. Local dev iterating against an existing instance will need `spacetime delete <db>` before republishing, or a clean redeploy.

## Follow-ups (not in this PR)

- File tracking issues for persistence ladder L2–L4 in the arcane repo (task #28).
- Consider matching column additions in `benchmark-spacetimedb-full` and `spacetimedb_demo` modules for hygiene (neither is called by this path; not blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
