### PR TITLE
feat(harness): validity gate for SpacetimeDB-only mode

### DIFF
--- a/scripts/BenchmarkHarnessHelpers.ps1
+++ b/scripts/BenchmarkHarnessHelpers.ps1
@@ -113,28 +113,28 @@ function Invoke-SpacetimeDbEntityCountQuery {
     [int]$TimeoutSec = 5
   )
   $uri = ('{0}/v1/database/{1}/sql' -f $SpacetimeHost.TrimEnd('/'), $Database)
-  $body = "SELECT COUNT(*) FROM $Table"
+  # SpacetimeDB's SQL engine rejects aggregate expressions without a column alias
+  # ("Aggregate expressions must have column aliases"), so `AS n` is required.
+  $body = "SELECT COUNT(*) AS n FROM $Table"
   try {
     $resp = Invoke-WebRequest -Uri $uri -Method Post -Body $body -ContentType 'text/plain' `
       -UseBasicParsing -TimeoutSec $TimeoutSec -ErrorAction Stop
-    # Try the structured shape first: array with .rows = [[N]].
+    # Only accept the structured SpacetimeDB SQL result shape: array with .rows = [[N]].
+    # Any other shape (including error bodies that happen to contain integers) returns
+    # $null so the caller keeps polling instead of accepting a bogus count.
     $parsed = $null
-    try { $parsed = $resp.Content | ConvertFrom-Json -ErrorAction Stop } catch {}
-    if ($parsed) {
-      foreach ($entry in @($parsed)) {
-        if ($null -ne $entry.rows) {
-          foreach ($r in @($entry.rows)) {
-            $vals = @($r)
-            if ($vals.Count -gt 0) {
-              $n = 0L
-              if ([int64]::TryParse([string]$vals[0], [ref]$n)) { return [int64]$n }
-            }
+    try { $parsed = $resp.Content | ConvertFrom-Json -ErrorAction Stop } catch { return $null }
+    foreach ($entry in @($parsed)) {
+      if ($null -ne $entry.rows) {
+        foreach ($r in @($entry.rows)) {
+          $vals = @($r)
+          if ($vals.Count -gt 0) {
+            $n = 0L
+            if ([int64]::TryParse([string]$vals[0], [ref]$n)) { return [int64]$n }
           }
         }
       }
     }
-    # Fall back to grabbing the first integer in the body.
-    if ($resp.Content -match '(\d+)') { return [int64]$Matches[1] }
     return $null
   } catch {
     return $null

--- a/scripts/BenchmarkHarnessHelpers.ps1
+++ b/scripts/BenchmarkHarnessHelpers.ps1
@@ -100,6 +100,92 @@ function Wait-ArcaneClustersReachEntityCount {
   }
 }
 
+# POST a COUNT query to SpacetimeDB's HTTP SQL endpoint and return the number.
+# SpacetimeDB 2.x exposes `POST /v1/database/{name}/sql` with the SQL text as body.
+# Anonymous access works when the module was published with --anonymous (which
+# docker/benchmark-publish-module.sh does). Returns $null on any failure —
+# callers treat null as "couldn't verify", not "0 entities".
+function Invoke-SpacetimeDbEntityCountQuery {
+  param(
+    [Parameter(Mandatory)][string]$SpacetimeHost,
+    [Parameter(Mandatory)][string]$Database,
+    [string]$Table = 'entity',
+    [int]$TimeoutSec = 5
+  )
+  $uri = ('{0}/v1/database/{1}/sql' -f $SpacetimeHost.TrimEnd('/'), $Database)
+  $body = "SELECT COUNT(*) FROM $Table"
+  try {
+    $resp = Invoke-WebRequest -Uri $uri -Method Post -Body $body -ContentType 'text/plain' `
+      -UseBasicParsing -TimeoutSec $TimeoutSec -ErrorAction Stop
+    # Try the structured shape first: array with .rows = [[N]].
+    $parsed = $null
+    try { $parsed = $resp.Content | ConvertFrom-Json -ErrorAction Stop } catch {}
+    if ($parsed) {
+      foreach ($entry in @($parsed)) {
+        if ($null -ne $entry.rows) {
+          foreach ($r in @($entry.rows)) {
+            $vals = @($r)
+            if ($vals.Count -gt 0) {
+              $n = 0L
+              if ([int64]::TryParse([string]$vals[0], [ref]$n)) { return [int64]$n }
+            }
+          }
+        }
+      }
+    }
+    # Fall back to grabbing the first integer in the body.
+    if ($resp.Content -match '(\d+)') { return [int64]$Matches[1] }
+    return $null
+  } catch {
+    return $null
+  }
+}
+
+# Poll SpacetimeDB's entity table row count until it reaches the target ratio
+# of the swarm's declared player count, or until timeout. Mirrors
+# Wait-ArcaneClustersReachEntityCount for the SpacetimeDB-only scenario.
+# Returns the same @{ Ready; FinalTotal; ElapsedSec; Detail } hashtable.
+function Wait-SpacetimeDbReachEntityCount {
+  param(
+    [Parameter(Mandatory)][string]$SpacetimeHost,
+    [Parameter(Mandatory)][string]$Database,
+    [string]$Table = 'entity',
+    [Parameter(Mandatory)][int]$TargetEntities,
+    [double]$ReachedRatioMin = 0.95,
+    [int]$TimeoutSeconds = 180,
+    [int]$PollIntervalSeconds = 2
+  )
+  $required = [int][Math]::Ceiling($TargetEntities * $ReachedRatioMin)
+  $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+  $started = Get-Date
+  $lastTotal = -1
+  $lastDetail = ''
+  while ((Get-Date) -lt $deadline) {
+    $n = Invoke-SpacetimeDbEntityCountQuery -SpacetimeHost $SpacetimeHost -Database $Database -Table $Table -TimeoutSec 5
+    if ($null -eq $n) {
+      $lastDetail = "spacetime $SpacetimeHost/$Database UNREACHABLE"
+    } else {
+      $lastTotal = [int]$n
+      $lastDetail = "spacetime $SpacetimeHost/$Database entities=$lastTotal"
+      if ($lastTotal -ge $required) {
+        return @{
+          Ready      = $true
+          FinalTotal = $lastTotal
+          ElapsedSec = ((Get-Date) - $started).TotalSeconds
+          Detail     = $lastDetail
+        }
+      }
+    }
+    Start-Sleep -Seconds $PollIntervalSeconds
+  }
+  return @{
+    Ready      = $false
+    FinalTotal = $lastTotal
+    ElapsedSec = ((Get-Date) - $started).TotalSeconds
+    Detail     = "ramp timed out after ${TimeoutSeconds}s: reached $lastTotal / $required required (target $TargetEntities). $lastDetail"
+  }
+}
+
 function Test-IsLocalLoopbackHostName([string]$TargetHost) {
   if ([string]::IsNullOrWhiteSpace($TargetHost)) { return $true }
   $x = $TargetHost.Trim().ToLowerInvariant()

--- a/scripts/Run-Benchmark.ps1
+++ b/scripts/Run-Benchmark.ps1
@@ -100,10 +100,12 @@ $ErrorActionPreference = 'Stop'
 
 . (Join-Path $PSScriptRoot 'BenchmarkHarnessHelpers.ps1')
 
-# Accumulator for per-tier server-side evidence (populated by Run-Scenario-Arcane,
-# consumed by Export-BenchmarkRunManifest). Initialized at script scope so
-# callers don't have to thread it through every function boundary.
+# Accumulators for per-tier server-side evidence (populated by Run-Scenario-Arcane /
+# Run-Scenario-SpacetimeOnly, consumed by Export-BenchmarkRunManifest).
+# Initialized at script scope so callers don't have to thread them through every
+# function boundary.
 $script:ArcaneRunEvidence = @()
+$script:SpacetimeOnlyRunEvidence = @()
 
 Merge-ConfigFileParameters -Path $ConfigFile
 
@@ -416,16 +418,21 @@ function Export-BenchmarkRunManifest {
     $bin.arcane_cluster = Get-BinaryInfo -LiteralPath $ArcaneClusterExe
   }
 
-  # Per-tier server-side evidence gathered by Run-Scenario-Arcane. If any tier
-  # came back invalid (cluster didn't see the entities the swarm claims to have
-  # spawned) the run is INVALID regardless of swarm-side pass/fail.
+  # Per-tier server-side evidence gathered by Run-Scenario-Arcane and
+  # Run-Scenario-SpacetimeOnly. If any tier came back invalid (cluster or
+  # SpacetimeDB didn't see the entities the swarm claims to have spawned) the
+  # run is INVALID regardless of swarm-side pass/fail.
   $arcaneEvidence = @(if ($null -ne $script:ArcaneRunEvidence) { $script:ArcaneRunEvidence } else { @() })
-  $invalidTiers = @($arcaneEvidence | Where-Object { -not $_.tier_valid })
-  $runValid = ($invalidTiers.Count -eq 0)
+  $spacetimeEvidence = @(if ($null -ne $script:SpacetimeOnlyRunEvidence) { $script:SpacetimeOnlyRunEvidence } else { @() })
+  $allEvidence = @($arcaneEvidence + $spacetimeEvidence)
+  $invalidTiers = @($allEvidence | Where-Object { -not $_.tier_valid })
+  $runValid = ($invalidTiers.Count -eq 0 -and $allEvidence.Count -gt 0)
   $validityFailures = @($invalidTiers | ForEach-Object {
+      $scenarioName = if ($_.PSObject.Properties.Name -contains 'scenario' -and $_.scenario) { [string]$_.scenario } else { 'arcane_plus_spacetimedb' }
+      $nsValue = if ($_.PSObject.Properties.Name -contains 'num_servers') { $_.num_servers } else { $null }
       [ordered]@{
-        scenario        = 'arcane_plus_spacetimedb'
-        num_servers     = $_.num_servers
+        scenario        = $scenarioName
+        num_servers     = $nsValue
         players         = $_.players
         reason          = $_.validity_reason
       }
@@ -440,7 +447,7 @@ function Export-BenchmarkRunManifest {
     run_error        = $(if ([string]::IsNullOrWhiteSpace($ErrorMessage)) { $null } else { $ErrorMessage })
     run_valid        = $runValid
     validity_failures = $validityFailures
-    per_tier_evidence = @($arcaneEvidence)
+    per_tier_evidence = @($allEvidence)
     harness          = @{
       script               = 'Run-Benchmark.ps1'
       benchmark_repo_root  = [string]$BenchmarkRoot
@@ -636,7 +643,30 @@ function Run-Scenario-SpacetimeOnly {
     while ($players -le $ScenarioMaxPlayers) {
       Write-Host "  [SpacetimeDB-only] testing players=$players ..." -ForegroundColor Gray
       Send-SwarmCommand -Port $ControlPort -Line "SET_PLAYERS $players"
-      Start-Sleep -Seconds 2
+
+      # Mirror the Arcane-mode validity gate: wait for SpacetimeDB's entity table to
+      # reflect the swarm's declared count before starting the measurement window.
+      # Without this, an empty or broken SpacetimeDB would silently "pass" the tier
+      # on swarm-side metrics alone, the way the pre-gate Arcane path used to.
+      $ramp = Wait-SpacetimeDbReachEntityCount -SpacetimeHost $SpacetimeHost -Database $DatabaseName `
+        -TargetEntities $players -ReachedRatioMin $ArcaneRampReachedRatio `
+        -TimeoutSeconds $ArcaneRampTimeoutSeconds -PollIntervalSeconds 2
+      Write-Host ("    [ramp] reached={0} target~{1} elapsed={2:N1}s ready={3}" `
+          -f $ramp.FinalTotal, $players, $ramp.ElapsedSec, $ramp.Ready) -ForegroundColor DarkGray
+      if (-not $ramp.Ready) {
+        Write-Host ("    [invalid] tier players=$players RAMP FAILED: $($ramp.Detail)") -ForegroundColor Yellow
+        $script:SpacetimeOnlyRunEvidence += [PSCustomObject]@{
+          scenario           = 'spacetimedb_only'
+          players            = $players
+          swarm_pass         = $false
+          entities_observed  = $ramp.FinalTotal
+          entities_required  = [int][Math]::Ceiling($players * $ArcaneRampReachedRatio)
+          tier_valid         = $false
+          validity_reason    = "ramp timeout: $($ramp.Detail)"
+        }
+        break
+      }
+
       Send-SwarmCommand -Port $ControlPort -Line 'RESET'
       Start-Sleep -Seconds $DurationSeconds
       Send-SwarmCommand -Port $ControlPort -Line 'REPORT'
@@ -646,6 +676,16 @@ function Run-Scenario-SpacetimeOnly {
       if (Test-Path $stderr) { $txt = Get-Content -Path $stderr -Raw -ErrorAction SilentlyContinue }
       $parsed = Parse-SwarmFinal $txt
       $pass = Test-BenchmarkPass $parsed
+
+      $script:SpacetimeOnlyRunEvidence += [PSCustomObject]@{
+        scenario           = 'spacetimedb_only'
+        players            = $players
+        swarm_pass         = [bool]$pass
+        entities_observed  = $ramp.FinalTotal
+        entities_required  = [int][Math]::Ceiling($players * $ArcaneRampReachedRatio)
+        tier_valid         = [bool]$pass
+        validity_reason    = $(if ($pass) { '' } else { 'swarm pass criteria not met (err_rate/latency)' })
+      }
 
       if ($pass) {
         $ceiling = $players
@@ -949,10 +989,20 @@ function Invoke-BenchmarkPhase {
     Write-Host '  Ceiling numbers below are swarm-side only and MUST NOT be treated as a saturation measurement.' -ForegroundColor Red
   }
 
+  $spInvalid = @($script:SpacetimeOnlyRunEvidence | Where-Object { -not $_.tier_valid })
+  if ($spInvalid.Count -gt 0) {
+    Write-Host "`n!!! INVALID SPACETIMEDB-ONLY RUN !!! $($spInvalid.Count) tier(s) failed server-side evidence check." -ForegroundColor Red
+    foreach ($t in $spInvalid) {
+      Write-Host ("  - players=$($t.players): $($t.validity_reason)") -ForegroundColor Red
+    }
+    Write-Host '  Ceiling numbers below are swarm-side only and MUST NOT be treated as a saturation measurement.' -ForegroundColor Red
+  }
+
   Write-Host "`n--- Ceiling summary ---" -ForegroundColor Cyan
   $sp = ($results | Where-Object { $_.backend -eq 'spacetimedb_only' } | Select-Object -First 1).ceiling_players
   $spLabel = if ($null -eq $sp) { 'none (no passing tier in this sweep)' } else { "$sp" }
-  Write-Host "  SpacetimeDB only: ceiling = $spLabel players"
+  $spSuffix = if ($spInvalid.Count -gt 0) { ' [INVALID — see warning above]' } else { '' }
+  Write-Host "  SpacetimeDB only: ceiling = $spLabel players$spSuffix"
   foreach ($r in ($results | Where-Object { $_.backend -eq 'arcane_plus_spacetimedb' } | Sort-Object { $_.num_servers })) {
     $suffix = if ($arcaneInvalid.Count -gt 0) { ' [INVALID — see warning above]' } else { '' }
     Write-Host "  Arcane + SpacetimeDB ($($r.num_servers) cluster(s)): ceiling = $($r.ceiling_players) players$suffix"

--- a/tests/BenchmarkHarnessHelpers.Tests.ps1
+++ b/tests/BenchmarkHarnessHelpers.Tests.ps1
@@ -92,6 +92,23 @@ Describe 'Test-IsLocalLoopbackHostName' {
   }
 }
 
+Describe 'Invoke-SpacetimeDbEntityCountQuery' {
+  It 'returns $null when the host is unreachable' {
+    # Port 1 is always refused on Linux/Windows test runners; keeps the test hermetic.
+    $r = Invoke-SpacetimeDbEntityCountQuery -SpacetimeHost 'http://127.0.0.1:1' -Database 'nope' -TimeoutSec 2
+    $r | Should -BeNullOrEmpty
+  }
+}
+
+Describe 'Wait-SpacetimeDbReachEntityCount' {
+  It 'returns Ready=false and reports timeout when the host is unreachable' {
+    $r = Wait-SpacetimeDbReachEntityCount -SpacetimeHost 'http://127.0.0.1:1' -Database 'nope' `
+      -TargetEntities 100 -TimeoutSeconds 2 -PollIntervalSeconds 1
+    $r.Ready | Should -BeFalse
+    $r.Detail | Should -Match 'ramp timed out'
+  }
+}
+
 Describe 'Assert-ArcaneTopologyForSweep' {
   It 'no-ops when FindArcaneCeiling is false' {
     { Assert-ArcaneTopologyForSweep -FindArcaneCeiling $false -ArcaneClusterCounts @(1, 2) -ArcaneClusterHosts @() -ArcaneClusterPortStride 1 -ArcaneExternalProcesses $false -ArcaneManagerHost '10.0.0.1' } | Should -Not -Throw


### PR DESCRIPTION
## Summary

Parallel validity gate for the SpacetimeDB-only mode so the published comparison number can stop inheriting the silent-invalid failure mode the pre-gate Arcane path used to have.

Today's `Run-Scenario-SpacetimeOnly` does `Start-Sleep -Seconds 2` after `SET_PLAYERS` and then accepts a "pass" purely on the swarm's self-reported `err_rate`/`avg_latency` — exactly the shape that gave us the earlier unverified "Arcane 6000" number. This PR plugs that hole.

## What changed

- **`Invoke-SpacetimeDbEntityCountQuery`** (helpers) — POSTs `SELECT COUNT(*) FROM entity` to `POST /v1/database/{db}/sql`. Returns the parsed integer count, or `$null` on any failure (null = "couldn't verify", not "0 entities").
- **`Wait-SpacetimeDbReachEntityCount`** (helpers) — polls the count every 2 s, returns `Ready=true` at 95 % of target, `Ready=false` on 180 s timeout. Same hashtable shape as `Wait-ArcaneClustersReachEntityCount`.
- **`Run-Scenario-SpacetimeOnly`** (harness) — calls `Wait-SpacetimeDbReachEntityCount` before every measurement window. Emits per-tier evidence into `$script:SpacetimeOnlyRunEvidence`; breaks the sweep on ramp timeout.
- **Manifest** — `per_tier_evidence` now merges Arcane and SpacetimeDB-only evidence; `validity_failures` keeps the `scenario` field so downstream consumers can distinguish; `run_valid` now reflects both. Summary prints the "INVALID" banner for SpacetimeDB-only tiers the same way it does for Arcane.
- **Pester tests** — added unit tests for the two new helpers (unreachable-host sad paths; avoids needing a real SpacetimeDB in CI).

## Why no library-side change

The `benchmark-spacetimedb-full` module's `Entity` table is already `public`, and `benchmark-publish-module.sh` publishes with `--anonymous`. The SQL endpoint is reachable without adding an auth token or a reducer. Purely a harness + helpers change.

## Test plan

- [x] `Invoke-ScriptAnalyzer -Path ./scripts -Recurse -Severity Error` — clean (same bar CI enforces).
- [x] PowerShell syntax parse of both scripts — clean.
- [ ] Pester tests run in CI (Pester 5 not installed locally; the new test cases use an unreachable `127.0.0.1:1` and are self-contained).
- [ ] End-to-end validation once CI passes: rebuild Docker image, spin up `topology=AwsSpacetimeOnly`, run `configs/spacetimedb_only.json`, confirm `run_valid=true` or a real reason for not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
