### PR TITLE
tune(arcane-2): start sweep at 500 players, extend ramp gate to 600s

### DIFF
--- a/configs/arcane_plus_spacetimedb.clusters_2.json
+++ b/configs/arcane_plus_spacetimedb.clusters_2.json
@@ -80,14 +80,25 @@
   //  adding ArcaneCeilingStep each tier, until it reaches
   //  ArcaneCeilingMaxPlayers OR a tier fails the pass criteria below.
 
-  // First tier. Integer >= 1.
-  "ArcaneCeilingStartPlayers": 1500,
+  // First tier. Integer >= 1. Set below the SpacetimeDB-only ceiling (500) so
+  // the first few Arcane tiers are head-to-head comparable and give us data
+  // points before we exit the range SpacetimeDB cleared on its own.
+  "ArcaneCeilingStartPlayers": 500,
   // Step size between tiers. Integer >= 1.
   "ArcaneCeilingStep":         250,
   // Upper bound on the sweep. Integer >= ArcaneCeilingStartPlayers.
   "ArcaneCeilingMaxPlayers":   6000,
   // Steady-state measurement window per tier, in seconds. Integer >= 1; 30 is canonical.
   "DurationSeconds":           30,
+
+  // ── validity-gate tuning (rarely changed; see BenchmarkHarnessHelpers.ps1) ─
+  //  The ramp-up gate waits for the clusters' /stats to reflect the swarm's
+  //  declared player count before starting the measurement window. 180 s is
+  //  fine for local runs, but on AWS with ~750 WS connections per c7i.2xlarge
+  //  cluster the ramp empirically needs several minutes at the higher tiers.
+  //  600 s gives room up through ~6000 players without obscuring a real
+  //  saturation point.
+  "ArcaneRampTimeoutSeconds":  600,
 
   // ── persistence (Arcane → SpacetimeDB) ────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Two-line tweak to \`configs/arcane_plus_spacetimedb.clusters_2.json\` to make the next AWS benchmark run more informative:

- \`ArcaneCeilingStartPlayers\` **1500 → 500** — the previous high-start config gave us zero data points below 1500 when the ceiling lived at 1250. Starting at 500 walks the sweep through 500/750/1000/1250/1500/1750/2000+, so we can see exactly where the post-Shape-B ceiling sits.
- \`ArcaneRampTimeoutSeconds\` (default 180s) **added as 600** — Shape B should cut the WS-accept CPU pressure enough that 180s is plausibly sufficient, but at higher tiers (2000+ players, 1000+ WS handshakes per cluster) the ramp still takes minutes. 600s keeps the gate from tripping on a slow ramp rather than a real saturation.

## Why now

Now that Shape B has landed in \`arcane\` and we bumped the submodule (PR #31), the next AWS run wants to measure the full post-fix picture. Starting at 1500 would miss the regression-validation data points entirely; starting at 500 gives us apples-to-apples comparison with the pre-Shape-B run (\`20260420_021048\`, which reached 1250 before the 1500 wall).

## Impact

- \`configs/arcane_plus_spacetimedb.clusters_2.json\` only. Two values changed. Canonical workload parameters (tick rate, burst profile, pass criteria) untouched — ceiling numbers from this config remain comparable to prior runs.
- No code changes, no submodule changes.

## Test plan

- [x] Config validator accepts both fields (\`ArcaneRampTimeoutSeconds\` already in Merge-ConfigFileParameters' supported list from the two-tier fix).
- [ ] After merge: rerun the Arcane 2-cluster benchmark with \`ghcr.io/brainy-bots/arcane-benchmark:dev-20260420-shape-b\`. Expected ceiling: ≥2000.

🤖 Generated with [Claude Code](https://claude.com/claude-code)