### PR TITLE
feat(observability): per-tier /stats snapshots + classifier; fix diag capture

### DIFF
--- a/infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1
+++ b/infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1
@@ -303,8 +303,21 @@ echo "diag uploaded to __DIAG_ROOT__/$LABEL/"
         $script = $script -replace "`r`n", "`n"
         $dcId = Send-SsmRunShellScript -Region $Region -InstanceId $n.InstanceId -ScriptBody $script `
           -Comment "Arcane arph diag $($n.Label) $RunId" -TimeoutSeconds 300
-        $null = Wait-SsmCommandInvocation -Region $Region -InstanceId $n.InstanceId -CommandId $dcId `
+        $diagInv = Wait-SsmCommandInvocation -Region $Region -InstanceId $n.InstanceId -CommandId $dcId `
           -Label "Diag $($n.Label)" -PollSeconds 3
+        # Wait-SsmCommandInvocation returns without throwing even on Status=Failed
+        # (diag is best-effort, so we don't want one failure to abort teardown).
+        # Surface the on-host stderr tail when the script fails so future diag
+        # breakages are self-diagnosing instead of appearing as a silent "5/5 Failed".
+        if ($diagInv.Status -ne 'Success') {
+          $errTail = ($diagInv.StandardErrorContent -split "`n" | Select-Object -Last 20) -join "`n"
+          $outTail = ($diagInv.StandardOutputContent -split "`n" | Select-Object -Last 10) -join "`n"
+          Write-Warning "Diag capture for $($n.Label) ($($n.InstanceId)) Status=$($diagInv.Status)."
+          Write-Host "--- diag stderr tail ---" -ForegroundColor DarkGray
+          Write-Host $errTail
+          Write-Host "--- diag stdout tail ---" -ForegroundColor DarkGray
+          Write-Host $outTail
+        }
       } catch {
         Write-Warning "Diag capture for $($n.Label) ($($n.InstanceId)) failed: $($_.Exception.Message). Continuing with remaining nodes."
       }

--- a/infra/terraform/aws_benchmark/user_data/docker_only.sh
+++ b/infra/terraform/aws_benchmark/user_data/docker_only.sh
@@ -2,7 +2,7 @@
 set -euo pipefail
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y ca-certificates curl gnupg
+apt-get install -y ca-certificates curl gnupg unzip
 install -m 0755 -d /etc/apt/keyrings
 curl -fsSL https://download.docker.com/linux/ubuntu/gpg | gpg --dearmor -o /etc/apt/keyrings/docker.gpg
 chmod a+r /etc/apt/keyrings/docker.gpg
@@ -10,3 +10,12 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.
 apt-get update -y
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
 systemctl enable --now docker
+
+# AWS CLI v2 — every node uses it to upload per-node diag logs (docker logs,
+# top/free/load snapshots) to the artifacts S3 bucket under each run's prefix.
+# Without this the diag SSM step fails on every worker node (aws: command not
+# found) and container logs never reach S3, leaving tier failures unattributable.
+curl -fsSL "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip" -o /tmp/awscliv2.zip
+unzip -q /tmp/awscliv2.zip -d /tmp
+/tmp/aws/install
+rm -rf /tmp/aws /tmp/awscliv2.zip

--- a/scripts/BenchmarkHarnessHelpers.ps1
+++ b/scripts/BenchmarkHarnessHelpers.ps1
@@ -789,6 +789,52 @@ function Run-Scenario-Arcane {
           -f $ramp.FinalTotal, $players, $ramp.ElapsedSec, $ramp.Ready) -ForegroundColor DarkGray
       if (-not $ramp.Ready) {
         Write-Host ("    [invalid] tier players=$players RAMP FAILED: $($ramp.Detail)") -ForegroundColor Yellow
+        # Take a final snapshot so the failed tier carries the same saturation
+        # counters the pass path records, then classify the most-overloaded
+        # component. This is how ramp-timeout tiers get attribution.
+        $rampSnapshots = @()
+        for ($i = 0; $i -lt $clusterHostsForRamp.Count; $i++) {
+          $ch = $clusterHostsForRamp[$i]
+          $wsPort = $ArcaneClusterBasePort + ($i * $ArcaneClusterPortStride)
+          $statsPort = $wsPort + 1
+          $json = Get-ArcaneClusterStatsJson -ClusterHost $ch -ClusterStatsPort $statsPort -TimeoutSec 5
+          if ($null -eq $json) {
+            $rampSnapshots += [PSCustomObject]@{ cluster_index = $i; host = $ch; stats_port = $statsPort; reachable = $false }
+          } else {
+            $rampSnapshots += [PSCustomObject]@{
+              cluster_index           = $i
+              host                    = $ch
+              stats_port              = $statsPort
+              reachable               = $true
+              entities_current        = [int64]$json.entities_current
+              msgs_player_state       = [int64]$json.msgs_player_state
+              msgs_game_action        = [int64]$json.msgs_game_action
+              parse_failures          = [int64]$json.parse_failures
+              bytes_in                = [int64]$json.bytes_in
+              bytes_out               = if ($null -ne $json.bytes_out) { [int64]$json.bytes_out } else { 0 }
+              broadcast_lagged_events = if ($null -ne $json.broadcast_lagged_events) { [int64]$json.broadcast_lagged_events } else { 0 }
+              broadcast_lagged_frames = if ($null -ne $json.broadcast_lagged_frames) { [int64]$json.broadcast_lagged_frames } else { 0 }
+              ws_send_errors          = if ($null -ne $json.ws_send_errors) { [int64]$json.ws_send_errors } else { 0 }
+              ws_accepts              = [int64]$json.ws_accepts
+              tick                    = [int64]$json.tick
+              last_tick_us            = [int64]$json.last_tick_us
+            }
+          }
+        }
+        $worstLagged = 0; $worstLaggedIdx = -1; $worstSendErr = 0; $worstSendErrIdx = -1
+        foreach ($snap in $rampSnapshots) {
+          if (-not $snap.reachable) { continue }
+          if ($snap.broadcast_lagged_events -gt $worstLagged) { $worstLagged = $snap.broadcast_lagged_events; $worstLaggedIdx = $snap.cluster_index }
+          if ($snap.ws_send_errors -gt $worstSendErr) { $worstSendErr = $snap.ws_send_errors; $worstSendErrIdx = $snap.cluster_index }
+        }
+        $mostOverloaded = if ($worstLagged -gt 0) {
+          "cluster[$worstLaggedIdx]:broadcast_lagged=$worstLagged"
+        } elseif ($worstSendErr -gt 0) {
+          "cluster[$worstSendErrIdx]:ws_send_errors=$worstSendErr"
+        } else {
+          'driver_or_network (cluster counters clean; check swarm stderr drv_cpu)'
+        }
+        Write-Host "    [invalid] ramp-timeout most_overloaded=$mostOverloaded" -ForegroundColor Yellow
         $script:ArcaneRunEvidence += [PSCustomObject]@{
           num_servers               = $NumServers
           players                   = $players
@@ -797,6 +843,8 @@ function Run-Scenario-Arcane {
           cluster_entities_required = [int][Math]::Ceiling($players * $ArcaneRampReachedRatio)
           tier_valid                = $false
           validity_reason           = "ramp timeout: $($ramp.Detail)"
+          most_overloaded           = $mostOverloaded
+          cluster_stats             = $rampSnapshots
         }
         break
       }
@@ -814,6 +862,11 @@ function Run-Scenario-Arcane {
       $entitiesObserved = 0
       $statsPollOk = $true
       $statsDetail = @()
+      # Full /stats snapshot per cluster, preserved on the evidence record so a
+      # post-mortem can attribute a tier failure to a specific saturation mode
+      # (broadcast fan-out lag, WS egress errors, inbound message drops, etc.)
+      # instead of only the ramp-timeout symptom.
+      $clusterStatsSnapshots = @()
       for ($i = 0; $i -lt $NumServers; $i++) {
         $ch = if ($ArcaneClusterHosts.Count -eq 0) { '127.0.0.1' } else { $ArcaneClusterHosts[$i] }
         $wsPort = $ArcaneClusterBasePort + ($i * $ArcaneClusterPortStride)
@@ -822,9 +875,33 @@ function Run-Scenario-Arcane {
         if ($null -eq $json) {
           $statsPollOk = $false
           $statsDetail += "cluster[$i] $ch`:$statsPort UNREACHABLE"
+          $clusterStatsSnapshots += [PSCustomObject]@{
+            cluster_index = $i
+            host          = $ch
+            stats_port    = $statsPort
+            reachable     = $false
+          }
         } else {
           $entitiesObserved += [int]$json.entities_current
           $statsDetail += "cluster[$i] $ch`:$statsPort entities=$($json.entities_current) msgs_ps=$($json.msgs_player_state) parse_fail=$($json.parse_failures)"
+          $clusterStatsSnapshots += [PSCustomObject]@{
+            cluster_index           = $i
+            host                    = $ch
+            stats_port              = $statsPort
+            reachable               = $true
+            entities_current        = [int64]$json.entities_current
+            msgs_player_state       = [int64]$json.msgs_player_state
+            msgs_game_action        = [int64]$json.msgs_game_action
+            parse_failures          = [int64]$json.parse_failures
+            bytes_in                = [int64]$json.bytes_in
+            bytes_out               = if ($null -ne $json.bytes_out) { [int64]$json.bytes_out } else { 0 }
+            broadcast_lagged_events = if ($null -ne $json.broadcast_lagged_events) { [int64]$json.broadcast_lagged_events } else { 0 }
+            broadcast_lagged_frames = if ($null -ne $json.broadcast_lagged_frames) { [int64]$json.broadcast_lagged_frames } else { 0 }
+            ws_send_errors          = if ($null -ne $json.ws_send_errors) { [int64]$json.ws_send_errors } else { 0 }
+            ws_accepts              = [int64]$json.ws_accepts
+            tick                    = [int64]$json.tick
+            last_tick_us            = [int64]$json.last_tick_us
+          }
         }
       }
       $required = [int][Math]::Ceiling($players * $ArcaneEntityObservedRatioMin)
@@ -841,6 +918,41 @@ function Run-Scenario-Arcane {
       Write-Host ("    [evidence] cluster_entities_observed={0} required>={1} valid={2}" `
           -f $observedForLog, $required, $tierValid) -ForegroundColor DarkGray
 
+      # Name the most-overloaded component so a failing tier points at a
+      # specific suspect instead of only reporting the ramp-timeout symptom.
+      # Cluster-side signals we can see from the driver are the /stats saturation
+      # counters (lag + WS send errors). Driver-side CPU is captured as
+      # per-second `[driver]` lines in the swarm stderr log; if the cluster
+      # counters are clean, the inference is "driver or network" and the
+      # caller is pointed at the swarm stderr for the drv_cpu timeline.
+      $mostOverloaded = 'unknown'
+      if (-not $tierValid) {
+        $worstLagged = 0
+        $worstSendErr = 0
+        $worstLaggedIdx = -1
+        $worstSendErrIdx = -1
+        foreach ($snap in $clusterStatsSnapshots) {
+          if (-not $snap.reachable) { continue }
+          if ($snap.broadcast_lagged_events -gt $worstLagged) {
+            $worstLagged = $snap.broadcast_lagged_events
+            $worstLaggedIdx = $snap.cluster_index
+          }
+          if ($snap.ws_send_errors -gt $worstSendErr) {
+            $worstSendErr = $snap.ws_send_errors
+            $worstSendErrIdx = $snap.cluster_index
+          }
+        }
+        if ($worstLagged -gt 0) {
+          $mostOverloaded = "cluster[$worstLaggedIdx]:broadcast_lagged=$worstLagged"
+        } elseif ($worstSendErr -gt 0) {
+          $mostOverloaded = "cluster[$worstSendErrIdx]:ws_send_errors=$worstSendErr"
+        } elseif (-not $statsPollOk) {
+          $mostOverloaded = 'cluster:unreachable'
+        } else {
+          $mostOverloaded = 'driver_or_network (cluster counters clean; check swarm stderr drv_cpu)'
+        }
+      }
+
       $script:ArcaneRunEvidence += [PSCustomObject]@{
         num_servers               = $NumServers
         players                   = $players
@@ -849,9 +961,11 @@ function Run-Scenario-Arcane {
         cluster_entities_required = $required
         tier_valid                = $tierValid
         validity_reason           = $validityReason
+        most_overloaded           = $mostOverloaded
+        cluster_stats             = $clusterStatsSnapshots
       }
       if (-not $tierValid) {
-        Write-Host ("    [invalid] tier players=$players FAILED validity: $validityReason") -ForegroundColor Yellow
+        Write-Host ("    [invalid] tier players=$players FAILED validity: $validityReason most_overloaded=$mostOverloaded") -ForegroundColor Yellow
         break
       }
 
@@ -1099,7 +1213,7 @@ function Export-ArcaneRunManifest {
   }
 
   $manifest = [ordered]@{
-    schema_version    = 5
+    schema_version    = 6
     scenario          = 'arcane_plus_spacetimedb'
     run_started_utc   = $StartedUtc.ToString('o')
     run_finished_utc  = $FinishedUtc.ToString('o')
@@ -1445,7 +1559,10 @@ function Invoke-ArcaneScenarioRun {
     $arcaneInvalid = @($script:ArcaneRunEvidence | Where-Object { -not $_.tier_valid })
     if ($arcaneInvalid.Count -gt 0) {
       Write-Host "`n!!! INVALID ARCANE RUN !!! $($arcaneInvalid.Count) tier(s) failed server-side evidence check." -ForegroundColor Red
-      foreach ($t in $arcaneInvalid) { Write-Host ("  - num_servers=$($t.num_servers) players=$($t.players): $($t.validity_reason)") -ForegroundColor Red }
+      foreach ($t in $arcaneInvalid) {
+        $mo = if ($t.PSObject.Properties['most_overloaded']) { " most_overloaded=$($t.most_overloaded)" } else { '' }
+        Write-Host ("  - num_servers=$($t.num_servers) players=$($t.players): $($t.validity_reason)$mo") -ForegroundColor Red
+      }
       Write-Host '  Ceiling numbers below are swarm-side only and MUST NOT be treated as a saturation measurement.' -ForegroundColor Red
     }
 


### PR DESCRIPTION
## Summary
Three pieces that together let a failing benchmark tier name which component saturated, instead of only reporting the ramp-timeout symptom.

### 1. AWS CLI on worker nodes
\`docker_only.sh\` user-data (cluster/redis/spacetime/manager nodes) installed Docker but never awscli, so the diag-capture SSM step's \`aws s3 cp\` failed with "command not found" on every worker — **5/5 Failed statuses every previous AWS run**. Adds the same awscli v2 install block the driver user-data already has. \`user_data_replace_on_change = true\` on each instance means the next \`terraform apply\` rotates them with the fix.

### 2. Diag capture surfaces its own failures
When an SSM diag invocation finishes with Status != Success, log the on-host stderr/stdout tail so future diag breakages are self-diagnosing instead of a silent "5/5 Failed".

### 3. Per-tier /stats snapshot + most-overloaded classifier
At every tier boundary — including the ramp-timeout branch — capture the full \`/stats\` JSON for every cluster (entities_current, msgs_player_state, bytes_in/out, broadcast_lagged_events/frames, ws_send_errors, tick, last_tick_us). On tier failure, pick the cluster with the highest Lagged-event count or WS send-error count as the suspect; if all cluster counters are clean, classify as \`driver_or_network\` and point at the swarm-stderr \`[driver]\` lines. Attach both \`most_overloaded\` and the full \`cluster_stats\` array to each \`per_tier_evidence\` entry. Bumps arcane-scenario manifest \`schema_version\` 5 → 6.

## Test plan
- [x] \`Invoke-Pester tests\` — 51 passed (BenchmarkHarnessHelpers, Layout, AwsHelpers, AwsBenchmarkRunValidation, Aws.EnvironmentRegistry)
- [x] \`Invoke-ScriptAnalyzer\` — no new errors introduced
- [x] PowerShell parse-check on modified scripts
- [ ] Next AWS rerun (after brainy-bots/arcane#37 + brainy-bots/arcane_swarm#11 merge and the image is rebuilt):
  - \`per_tier_evidence\` entries carry non-empty \`cluster_stats\`
  - failing tier shows \`most_overloaded=cluster[N]:... \` or \`driver_or_network\`
  - diag \`s3://.../diag/<label>/*.log\` contains per-container logs for each worker node

## Dependency chain
- **arcane_swarm#11** — driver CPU/RSS telemetry (required for the \`[driver]\` stderr lines this PR's classifier points at)
- **arcane#37** — cluster \`/stats\` saturation counters (required for the new fields this PR records)
- This PR — harness side that consumes both

🤖 Generated with [Claude Code](https://claude.com/claude-code)