### PR TITLE
tune(spacetimedb-only): step 250→50 for tier resolution near 500

### DIFF
--- a/configs/spacetimedb_only.json
+++ b/configs/spacetimedb_only.json
@@ -48,10 +48,16 @@
   //  fails the pass criteria below (whichever comes first). The ceiling is
   //  the highest tier that passed.
 
-  // First tier (also the step size). Integer >= 1.
-  "SpacetimeStep":        250,
-  // Upper bound on the sweep. Integer >= SpacetimeStep.
-  "SpacetimeMaxPlayers":  2000,
+  // First tier (also the step size). Integer >= 1. Step 50 gives us tier
+  // resolution every 50 players across the saturation region — prior 250-step
+  // runs landed pass=500/fail=750, which is not informative enough to say
+  // whether the real ceiling is 550, 650, or 720.
+  "SpacetimeStep":        50,
+  // Upper bound on the sweep. Integer >= SpacetimeStep. Sized with enough
+  // headroom over the observed ~500–750 saturation band so a step-50 sweep
+  // lands on at least one failing tier without running many wasted tiers past
+  // saturation.
+  "SpacetimeMaxPlayers":  1500,
   // Steady-state measurement window per tier, in seconds. The swarm settles
   // for this long between RESET and REPORT on each tier before pass/fail is
   // computed. Integer >= 1; 30 is the canonical published value.


### PR DESCRIPTION
## Summary
Prior AWS runs had \`SpacetimeStep=250\` and landed pass=500 / fail=750 (and the 750 failure was a ramp-timeout, not a clean saturation measurement). That resolution can't distinguish a real ceiling of 550, 650, or 720 — which matters now that we have a **3500-player Arcane ceiling** on the same image + harness and want a meaningful head-to-head number.

- \`SpacetimeStep\`: 250 → 50
- \`SpacetimeMaxPlayers\`: 2000 → 1500 (enough headroom over the observed saturation band)

On SpacetimeDB (HTTP, fast ramp) each tier is ~35s, so 14 tiers to reach the prior ~500–750 band is ~8 min of measurement. The sweep stops at first failing tier.

## Test plan
- [x] JSONC parses via the harness (no harness change — \`SpacetimeStep\` is both start and step, which is the existing contract)
- [ ] Rerun SpacetimeDB-only on AWS with the new image + this config; get a clean per-tier-50 saturation point

🤖 Generated with [Claude Code](https://claude.com/claude-code)