### PR TITLE
tune(spacetimedb-only): widen sweep to 6000 to find actual ceiling

### DIFF
--- a/configs/spacetimedb_only.json
+++ b/configs/spacetimedb_only.json
@@ -48,16 +48,18 @@
   //  fails the pass criteria below (whichever comes first). The ceiling is
   //  the highest tier that passed.
 
-  // First tier (also the step size). Integer >= 1. Step 50 gives us tier
-  // resolution every 50 players across the saturation region — prior 250-step
-  // runs landed pass=500/fail=750, which is not informative enough to say
-  // whether the real ceiling is 550, 650, or 720.
-  "SpacetimeStep":        50,
-  // Upper bound on the sweep. Integer >= SpacetimeStep. Sized with enough
-  // headroom over the observed ~500–750 saturation band so a step-50 sweep
-  // lands on at least one failing tier without running many wasted tiers past
-  // saturation.
-  "SpacetimeMaxPlayers":  1500,
+  // First tier (also the step size). Integer >= 1. Step 250 gives 24 tiers
+  // from 250 to 6000 — coarse but enough to find the tier at which
+  // SpacetimeDB actually saturates. A prior step-50 sweep showed 50→1500 all
+  // pass with flat ~50 ms latency and 0 errors (see run 20260421_142645), so
+  // that region is fully characterized and finer resolution below 1500 adds
+  // nothing. If this wide sweep finds a specific failing tier above 1500,
+  // rerun with a narrower step centered on it.
+  "SpacetimeStep":        250,
+  // Upper bound on the sweep. Integer >= SpacetimeStep. Set to 6000 to
+  // match the arcane_plus_spacetimedb configs' top tier so head-to-head
+  // numbers can share a common x-axis.
+  "SpacetimeMaxPlayers":  6000,
   // Steady-state measurement window per tier, in seconds. The swarm settles
   // for this long between RESET and REPORT on each tier before pass/fail is
   // computed. Integer >= 1; 30 is the canonical published value.


### PR DESCRIPTION
Prior step-50/max-1500 run passed all 30 tiers with flat ~50 ms latency and 0 errors. Need to localize where SpacetimeDB actually saturates for the head-to-head with Arcane 2-cluster's 3500-player ceiling. Step 250, max 6000, 24 tiers. Coarse-but-sufficient; rerun with finer step once the failing tier is known.