### PR TITLE
feat(config): add clusters_4.big_driver tfvars (c7i.4xlarge driver)

### DIFF
--- a/infra/terraform/aws_benchmark/arcaneperhost.clusters_4.big_driver.tfvars
+++ b/infra/terraform/aws_benchmark/arcaneperhost.clusters_4.big_driver.tfvars
@@ -1,0 +1,31 @@
+# Arcane-per-host topology with 4 clusters — same fleet shape as
+# `arcaneperhost.clusters_4.tfvars` (Redis + SpacetimeDB + manager +
+# 4 cluster nodes all on t3.large), but with the swarm driver
+# upgraded from c7i.2xlarge (8 vCPU) to c7i.4xlarge (16 vCPU).
+#
+# Purpose: isolate whether the 4-cluster ceiling / latency-climb /
+# broadcast-lag behavior is driver-limited. In the 2026-04-22
+# bounded-rayon runs the driver showed sustained 700-800% CPU
+# across the 8 vCPU box — a plausible bottleneck whose effect
+# propagates via TCP backpressure into the cluster's broadcast
+# channel. Doubling driver cores tests that hypothesis without
+# changing cluster hardware.
+#
+# Pair with `configs/arcane_plus_spacetimedb.clusters_4.json`.
+#
+# Use:
+#   terraform apply -var-file=arcaneperhost.clusters_4.big_driver.tfvars
+#
+# Commit rule: one file per scenario, never edited in place. If you
+# need a different driver size or cluster count, add a new sibling
+# rather than mutating this one.
+
+aws_region               = "us-east-1"
+topology                 = "AwsArcanePerHost"
+arcane_cluster_count     = 4
+instance_type            = "c7i.4xlarge"
+data_instance_type       = "t3.large"
+root_volume_gib          = 100
+artifact_prefix          = "benchmark-aws"
+remote_provision_profile = "Full"
+s3_bucket_force_destroy  = true


### PR DESCRIPTION
## Summary

Adds `arcaneperhost.clusters_4.big_driver.tfvars`, a sibling of the canonical 4-cluster scenario with the swarm driver upgraded from `c7i.2xlarge` (8 vCPU) to `c7i.4xlarge` (16 vCPU). All other roles — Redis, SpacetimeDB, manager, 4 cluster nodes — stay on `t3.large` exactly as in the canonical 4c scenario.

## Why

In the 2026-04-21 and 2026-04-22 benchmark runs the driver showed **sustained 700-800% CPU across its 8 vCPU box**. One hypothesis from the 2026-04-22 journal entry: the driver is CPU-saturated, TCP backpressure propagates to the cluster, and that's why `broadcast_lagged_events` explodes at high tiers. Doubling driver cores tests that hypothesis without changing cluster hardware.

## What this PR does NOT do

- Doesn't touch any cluster/manager/redis/spacetime hardware — only the driver.
- Doesn't modify any existing tfvars or configs — new file only.
- Doesn't change any code; this is a scenario-selection file.

## Plan

1. Merge this PR (or run from the branch as-is — the tfvars file is self-contained).
2. `terraform apply -var-file=arcaneperhost.clusters_4.big_driver.tfvars` with image `dev-20260422-bounded-rayon`.
3. Run 4c benchmark against config `arcane_plus_spacetimedb.clusters_4.json` (unchanged).
4. Journal the result in `docs/BENCHMARK_JOURNAL.md` (separate PR).
5. `terraform destroy`.

## Test plan

- [ ] New tfvars file lints (no terraform syntax issues when `terraform validate` runs against it)
- [ ] Existing scenario tfvars are unchanged
- [ ] Layout.Tests (Pester) still pass
- [ ] File follows the committed \"one file per scenario, never edit in place\" convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)