### PR TITLE
feat(config): clusters_4.big — c7i.2xlarge fleet for bounded-rayon decision test

### DIFF
--- a/configs/arcane_plus_spacetimedb.clusters_4.big.json
+++ b/configs/arcane_plus_spacetimedb.clusters_4.big.json
@@ -1,0 +1,95 @@
+{
+  // ═══════════════════════════════════════════════════════════════════════════
+  //  arcane_plus_spacetimedb — 4-cluster setup, big-fleet sweep.
+  //
+  //  Same scenario as `arcane_plus_spacetimedb.clusters_4.json` but tuned for
+  //  the c7i.2xlarge cluster fleet defined in
+  //  `arcaneperhost.clusters_4.big.tfvars`. Every workload knob (TickRateHz,
+  //  ActionsPerSec, burst profile, MaxLatencyMs) is identical to the t3.large
+  //  config so ceilings are directly comparable.
+  //
+  //  Sweep starts at 5750 — the tier right before the bounded-rayon run on
+  //  t3.large failed at 6000 (run 20260422_010033, ceiling 5750). The point
+  //  of this run is to test whether bounded rayon (arcane#40/#41) actually
+  //  wins when cluster nodes have cores to spare for the rayon pool. The
+  //  low tiers below 5750 are well-characterized on smaller hardware and
+  //  rerunning them here is a waste of EC2 — start at the interesting
+  //  question.
+  //
+  //  Decision rule on this run:
+  //   - If ceiling lifts meaningfully past 6000: bounded-rayon is justified;
+  //     run the full sweep (clusters_2/4/6 on big fleet) for new published
+  //     numbers.
+  //   - If ceiling is at or below 6000: bounded-rayon doesn't help even with
+  //     adequate cores; revert arcane#40/#41.
+  //
+  //  Comments use JSONC syntax (// line comments). The harness strips them
+  //  before calling ConvertFrom-Json.
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  // ── scenario ───────────────────────────────────────────────────────────────
+
+  "BenchmarkMode":      "ArcanePlusSpacetime",
+  "ArcaneClusterCount": 4,
+  "SpacetimeModule":    "benchmark-spacetimedb-persist",
+  "PhysicsEngine":      "kinematic",
+
+  // ── connectivity (local defaults; cloud drivers override at runtime) ──────
+
+  "SpacetimeHost":  "http://127.0.0.1:3000",
+  "DatabaseName":   "arcane",
+  "RedisHost":      "127.0.0.1",
+  "RedisPort":      6379,
+
+  // ── Arcane topology (local defaults; cloud drivers override at runtime) ───
+
+  "ArcaneManagerHost": "127.0.0.1",
+  "ArcaneManagerPort": 8081,
+  "ArcaneClusterHosts": [],
+  "ArcaneClusterBasePort":   8090,
+  "ArcaneClusterPortStride": 1,
+  "ArcaneExternalProcesses": false,
+
+  // ── sweep (start at the bounded-rayon t3.large failure boundary) ──────────
+
+  // 5750 = ceiling of bounded-rayon t3.large run (20260422_010033). Step up
+  // from there until failure to find the c7i.2xlarge cluster ceiling.
+  "ArcaneCeilingStartPlayers": 5750,
+  "ArcaneCeilingStep":         250,
+  // Wide upper bound — if the bigger fleet helps a lot we want to see the
+  // real failure tier in one run rather than topping out and re-running.
+  "ArcaneCeilingMaxPlayers":   10000,
+  "DurationSeconds":           30,
+
+  // ── validity-gate tuning ──────────────────────────────────────────────────
+
+  "ArcaneRampTimeoutSeconds":  600,
+
+  // ── persistence (Arcane → SpacetimeDB) ────────────────────────────────────
+
+  "SpacetimePersistHz": 1,
+  "PersistBatchSize":   0,
+
+  // ── pass / fail thresholds (canonical — must match clusters_4.json) ───────
+
+  "MaxErrRate":     0.01,
+  "MaxLatencyMs":   200,
+
+  // ── swarm client workload (canonical — must match clusters_4.json) ────────
+
+  "TickRateHz":               10,
+  "ActionsPerSec":            2,
+  "ReadRateHz":               5,
+  "SwarmMode":                "spread",
+  "BetweenIncrementsSeconds": 1,
+
+  // ── burst profile (canonical — matches clusters_4.json) ───────────────────
+
+  "BurstEnabled":           true,
+  "BurstPeriodSecs":        30,
+  "BurstCohortPercent":     20,
+  "BurstActionsPerPlayer":  10,
+  "BurstWindowMs":          500,
+  "ZoneEventPeriodSecs":    30,
+  "ZoneEventWindowMs":      500
+}

--- a/infra/terraform/aws_benchmark/arcaneperhost.clusters_4.big.tfvars
+++ b/infra/terraform/aws_benchmark/arcaneperhost.clusters_4.big.tfvars
@@ -1,0 +1,37 @@
+# Arcane-per-host topology with 4 clusters — same fleet shape as
+# `arcaneperhost.clusters_4.tfvars` but every server-side node
+# (Redis + SpacetimeDB + manager + 4 cluster nodes) upgraded from
+# t3.large (2 vCPU burstable, 8 GiB) to c7i.2xlarge (8 vCPU
+# sustained, 16 GiB). Driver stays at c7i.2xlarge.
+#
+# Purpose: test whether the bounded-rayon parallel pre-encoding
+# (arcane#40/#41) actually wins when cluster nodes have cores to
+# spare. On t3.large the rayon pool fights tokio for the same 2
+# vCPUs and the bounded run ceilinged at 5750 — *below* the serial
+# baseline of 6000. With 8 sustained vCPUs per cluster node, rayon
+# has room to spread without starving the WS server tasks.
+#
+# Decision rule: if ceiling lifts meaningfully past 6000, keep
+# bounded-rayon and run the full sweep (clusters_2/4/6) to publish
+# new numbers. If not, revert arcane#40/#41.
+#
+# Pair with `configs/arcane_plus_spacetimedb.clusters_4.big.json`
+# (sweep starts at 5750 — the tier just before the bounded-rayon
+# t3.large run failed at 6000).
+#
+# Use:
+#   terraform apply -var-file=arcaneperhost.clusters_4.big.tfvars
+#
+# Commit rule: one file per scenario, never edited in place. If you
+# need a different cluster size or count, add a new sibling rather
+# than mutating this one.
+
+aws_region               = "us-east-1"
+topology                 = "AwsArcanePerHost"
+arcane_cluster_count     = 4
+instance_type            = "c7i.2xlarge"
+data_instance_type       = "c7i.2xlarge"
+root_volume_gib          = 100
+artifact_prefix          = "benchmark-aws"
+remote_provision_profile = "Full"
+s3_bucket_force_destroy  = true


### PR DESCRIPTION
## Summary
- Adds `arcaneperhost.clusters_4.big.tfvars` — every server-side role (Redis + SpacetimeDB + manager + 4 cluster nodes) on c7i.2xlarge (8 vCPU sustained, 16 GiB) instead of t3.large. Driver stays c7i.2xlarge.
- Adds `arcane_plus_spacetimedb.clusters_4.big.json` — sweep starts at 5750 (tier before the bounded-rayon t3.large run failed at 6000 in run `20260422_010033`), step 250, max 10000.
- Purely additive (sibling files); no behavior change to existing scenarios.

## Why
On t3.large (2 vCPU) the rayon pool from arcane#40/#41 fights tokio for the same cores, which dropped the ceiling 6000 → 5750 vs the pre-rayon serial baseline (see [BENCHMARK_JOURNAL.md](docs/BENCHMARK_JOURNAL.md) entry "2026-04-22 — Parallel pre-encoding (bounded to num_cpus/2)"). With 8 sustained vCPUs per cluster node, rayon has room to spread without starving the WS server tasks.

This is the **decision criterion** for arcane#40/#41:
- Ceiling lifts meaningfully past 6000 → keep bounded-rayon, run full sweep (clusters_2/4/6 on big fleet) for new published numbers.
- Ceiling at or below 6000 → revert arcane#40/#41.

## Test plan
- [ ] CI green
- [ ] Run `terraform apply -var-file=arcaneperhost.clusters_4.big.tfvars` and `Run-Benchmark-Arcane.ps1 -ConfigFile ./configs/arcane_plus_spacetimedb.clusters_4.big.json`
- [ ] Append journal entry with the result
- [ ] Decide: keep #40/#41 + sweep, or revert

🤖 Generated with [Claude Code](https://claude.com/claude-code)