### PR TITLE
feat(bench): runtime cluster tick rate via ClusterTickRateHz config field

### DIFF
--- a/configs/arcane_plus_spacetimedb.clusters_4.tick30.json
+++ b/configs/arcane_plus_spacetimedb.clusters_4.tick30.json
@@ -1,0 +1,94 @@
+{
+  // ═══════════════════════════════════════════════════════════════════════════
+  //  arcane_plus_spacetimedb — 4-cluster setup, 30 Hz cluster tick rate.
+  //
+  //  Sibling of `arcane_plus_spacetimedb.clusters_4.json` that demonstrates
+  //  the new `ClusterTickRateHz` field. Workload is otherwise identical so
+  //  the only delta vs the 20 Hz baseline is the cluster simulation tick rate
+  //  and the broadcast cadence (which scales with it).
+  //
+  //  This is the headline-tier MMO config Arcane publishes against:
+  //    - cluster simulation at 30 Hz (above the 5–20 Hz incumbent MMO band)
+  //    - 100 ms latency gate (down from the 200 ms baseline)
+  //
+  //  See `docs/BENCHMARK_JOURNAL.md` for the rationale: at the 7,250-player
+  //  ceiling on c7i.2xlarge clusters, NIC outbound is the binding bottleneck;
+  //  raising tick rate from 20 → 30 increases broadcast bytes/sec by ~1.5×
+  //  and is expected to lower the player-count ceiling proportionally. The
+  //  framing is "Arcane sustains 30 Hz at scale; incumbents sustain 5–20 Hz"
+  //  — see `WHY_ARCANE.md` for the comparison-set detail.
+  //
+  //  Comments use JSONC syntax — the harness strips them before parsing.
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  // ── scenario ───────────────────────────────────────────────────────────────
+
+  "BenchmarkMode":      "ArcanePlusSpacetime",
+  "ArcaneClusterCount": 4,
+  "SpacetimeModule":    "benchmark-spacetimedb-persist",
+  "PhysicsEngine":      "kinematic",
+
+  // ── cluster simulation tick rate — the field this sibling exists to demo ──
+  //
+  //  Read by Run-Benchmark-Aws.ps1 and passed to the cluster container as
+  //  BENCHMARK_TICK_RATE_HZ. Unset = 20 Hz default (preserves prior runs).
+
+  "ClusterTickRateHz":  30,
+
+  // ── connectivity (cloud overrides at runtime) ─────────────────────────────
+
+  "SpacetimeHost":  "http://127.0.0.1:3000",
+  "DatabaseName":   "arcane",
+  "RedisHost":      "127.0.0.1",
+  "RedisPort":      6379,
+
+  // ── Arcane topology (cloud overrides at runtime) ──────────────────────────
+
+  "ArcaneManagerHost":     "127.0.0.1",
+  "ArcaneManagerPort":     8081,
+  "ArcaneClusterHosts":    [],
+  "ArcaneClusterBasePort": 8090,
+  "ArcaneClusterPortStride": 1,
+
+  // ── sweep — same range as clusters_4, no change ───────────────────────────
+  //
+  //  The 30 Hz run uses the same starting tier and step as the 20 Hz baseline
+  //  so per-tier comparison is direct. Ceiling tier will likely come earlier
+  //  (cluster outbound NIC scales with tick rate × bytes-per-broadcast).
+
+  "ArcaneStep":        500,
+  "ArcaneMaxPlayers":  10000,
+  "DurationSeconds":   60,
+
+  // ── persistence (Arcane → SpacetimeDB) ────────────────────────────────────
+
+  "SpacetimePersistHz": 1,
+  "PersistBatchSize":   0,
+
+  // ── pass / fail thresholds — 100 ms latency gate (MMO headline) ───────────
+  //
+  //  100 ms is the playability bar Arcane publishes against — tighter than
+  //  the historical 200 ms baseline. Sibling configs that want the 200 ms
+  //  number for back-comparison just override `MaxLatencyMs`.
+
+  "MaxErrRate":     0.01,
+  "MaxLatencyMs":   100,
+
+  // ── swarm client workload (canonical) ─────────────────────────────────────
+
+  "TickRateHz":               10,
+  "ActionsPerSec":            2,
+  "ReadRateHz":               5,
+  "SwarmMode":                "spread",
+  "BetweenIncrementsSeconds": 1,
+
+  // ── burst profile (canonical) ─────────────────────────────────────────────
+
+  "BurstEnabled":           true,
+  "BurstPeriodSecs":        30,
+  "BurstCohortPercent":     20,
+  "BurstActionsPerPlayer":  10,
+  "BurstWindowMs":          500,
+  "ZoneEventPeriodSecs":    30,
+  "ZoneEventWindowMs":      500
+}

--- a/crates/benchmark-cluster/Cargo.lock
+++ b/crates/benchmark-cluster/Cargo.lock
@@ -36,6 +36,7 @@ dependencies = [
  "arcane-spatial",
  "arcane-wire",
  "futures-util",
+ "rayon",
  "redis",
  "reqwest",
  "serde",
@@ -223,6 +224,31 @@ name = "critical-section"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crypto-common"
@@ -1058,6 +1084,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
 ]
 
 [[package]]

--- a/crates/benchmark-cluster/src/main.rs
+++ b/crates/benchmark-cluster/src/main.rs
@@ -57,10 +57,12 @@ fn main() -> Result<(), String> {
 
     let sim = BenchmarkSimulation::new();
 
+    // Buff duration is reported as wall-clock seconds (the user-visible thing),
+    // since the per-tick count varies with the cluster's tick rate.
     eprintln!(
-        "benchmark-cluster: physics=kinematic collision_radius={} buff_duration={}ticks",
+        "benchmark-cluster: physics=kinematic collision_radius={} buff_duration={}s",
         simulation::COLLISION_RADIUS,
-        simulation::BUFF_DURATION_TICKS,
+        simulation::BUFF_DURATION_SECONDS,
     );
 
     cluster_runner::run_cluster_loop(

--- a/crates/benchmark-cluster/src/simulation.rs
+++ b/crates/benchmark-cluster/src/simulation.rs
@@ -37,9 +37,20 @@ pub const WORLD_MAX: f64 = WORLD_SIZE - 200.0;
 pub const COLLISION_RADIUS: f64 = 50.0;
 pub const COLLISION_DAMAGE: u32 = 10;
 pub const BUFF_SPEED_MULTIPLIER: f64 = 2.0;
-pub const BUFF_DURATION_TICKS: u64 = 200; // 10 seconds at 20 Hz
+/// Buff lasts the same wall-clock duration regardless of cluster tick rate.
+/// Previously hardcoded as `BUFF_DURATION_TICKS = 200` (10s at 20 Hz). Now
+/// derived from `ctx.dt_seconds` per tick so a 30 Hz cluster runs the buff
+/// for 300 ticks and a 60 Hz cluster for 600 ticks — same 10 s on a clock.
+pub const BUFF_DURATION_SECONDS: f64 = 10.0;
 pub const INITIAL_HP: u32 = 100;
 const SPEED_POTION_ITEM: u32 = 0;
+
+/// How many ticks a 10-second speed buff covers at the current tick rate.
+/// `dt_seconds` is the cluster's per-tick interval; at 20 Hz this returns
+/// 200, at 30 Hz it returns 300.
+pub fn buff_duration_ticks(dt_seconds: f64) -> u64 {
+    (BUFF_DURATION_SECONDS / dt_seconds).round() as u64
+}
 
 #[derive(Default, Clone)]
 struct BuffState {
@@ -148,7 +159,7 @@ impl ClusterSimulation for BenchmarkSimulation {
                     if consumed && item_type == SPEED_POTION_ITEM {
                         gs.buff = Some(BuffState {
                             speed_multiplier: BUFF_SPEED_MULTIPLIER,
-                            expires_at_tick: tick + BUFF_DURATION_TICKS,
+                            expires_at_tick: tick + buff_duration_ticks(ctx.dt_seconds),
                         });
                     }
                 }
@@ -377,8 +388,10 @@ mod tests {
         run_tick(&sim, 2, &mut entities, &[use_it]);
         assert!(!entities.get(&id).unwrap().user_data["buff"].is_null());
 
-        // Advance past expiration.
-        run_tick(&sim, 2 + BUFF_DURATION_TICKS + 1, &mut entities, &[]);
+        // Advance past expiration. The test runs at dt = 0.05 (20 Hz) so the
+        // buff covers 200 ticks; the helper makes that explicit.
+        let expiry = 2 + buff_duration_ticks(0.05) + 1;
+        run_tick(&sim, expiry, &mut entities, &[]);
         assert!(entities.get(&id).unwrap().user_data["buff"].is_null());
     }
 

--- a/infra/aws/Run-Benchmark-Aws.ps1
+++ b/infra/aws/Run-Benchmark-Aws.ps1
@@ -162,6 +162,23 @@ if ([string]::IsNullOrWhiteSpace($img)) {
 $runId = Get-Date -Format 'yyyyMMdd_HHmmss'
 $Region = [string]$state.Region
 
+# Resolve the cluster simulation tick rate from the config. Optional field —
+# defaults to 20 to preserve historical behavior. The driver passes this to
+# the cluster container as BENCHMARK_TICK_RATE_HZ; the env-driven helper in
+# arcane-infra/tick_rate.rs picks it up. Sibling configs that want a higher
+# headline (e.g. the 30 Hz MMO standard) just set the field.
+. (Join-Path $script:__AwsBenchmarkRepoRoot 'scripts\BenchmarkConfigJsonc.ps1') 2>$null
+if (-not (Get-Command ConvertFrom-BenchmarkConfigJsonc -ErrorAction SilentlyContinue)) {
+  $repoRootForJsonc = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+  . (Join-Path $repoRootForJsonc 'scripts\BenchmarkConfigJsonc.ps1')
+}
+$cfgRaw = Get-Content -Raw -LiteralPath $cfgResolved
+$cfgJson = ConvertFrom-BenchmarkConfigJsonc -Text $cfgRaw
+$clusterTickRateHz = 20
+if ($cfgJson.PSObject.Properties.Name -contains 'ClusterTickRateHz') {
+  $clusterTickRateHz = [int]$cfgJson.ClusterTickRateHz
+}
+
 # Stage the local config to S3 so the driver can pull it at run time. This is
 # the mechanism that lets researchers add new sibling configs without rebuilding
 # the image: the orchestrator uploads, the driver downloads + bind-mounts, and
@@ -183,12 +200,14 @@ $remoteParams = @{
   BenchmarkImage                   = $img
   ContainerConfigPath              = $containerConfigPath
   S3ConfigUri                      = $s3ConfigUri
+  ClusterTickRateHz                = $clusterTickRateHz
   SsmDriverBenchmarkTimeoutSeconds = $SsmDriverBenchmarkTimeoutSeconds
 }
 
 Write-Host "Run benchmark on existing AWS env. Environment=$Environment RunId=$runId Region=$Region Image=$img" -ForegroundColor Cyan
 Write-Host "Config (in container): $containerConfigPath" -ForegroundColor DarkGray
 Write-Host "Config (S3 source):    $s3ConfigUri" -ForegroundColor DarkGray
+Write-Host "Cluster tick rate:     ${clusterTickRateHz} Hz" -ForegroundColor DarkGray
 Write-Host "S3 results prefix: s3://$bucket/$prefix/$Environment/$runId/" -ForegroundColor DarkYellow
 Write-Host "SSM driver benchmark timeout: ${SsmDriverBenchmarkTimeoutSeconds}s" -ForegroundColor DarkGray
 

--- a/infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1
+++ b/infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1
@@ -15,6 +15,7 @@ function Invoke-AwsArcanePerHostRemoteBenchmark {
     [Parameter(Mandatory)][string]$BenchmarkImage,
     [Parameter(Mandatory)][string]$ContainerConfigPath,
     [Parameter(Mandatory)][string]$S3ConfigUri,
+    [int]$ClusterTickRateHz = 20,
     [int]$SsmDriverBenchmarkTimeoutSeconds = 28800
   )
 
@@ -156,16 +157,18 @@ docker run -d --name arcane-bench-cluster --network host \
   -e SPACETIMEDB_DATABASE=arcane \
   -e SPACETIMEDB_PERSIST=1 \
   -e SPACETIMEDB_PERSIST_HZ=1 \
+  -e BENCHMARK_TICK_RATE_HZ="__TICK_RATE_HZ__" \
   "$IMG" benchmark-cluster
 for i in $(seq 1 60); do bash -c "echo >/dev/tcp/127.0.0.1/8090" 2>/dev/null && exit 0; sleep 1; done
 echo "ERROR: cluster WS not listening on 8090"; docker logs arcane-bench-cluster --tail 80 || true; exit 1
 '@
     $clScript = $clTpl.
-      Replace('__IMG__',        (Escape-BashDoubleQuoted $BenchmarkImage)).
-      Replace('__REDIS_IP__',   (Escape-BashDoubleQuoted $redisIp)).
-      Replace('__ST_IP__',      (Escape-BashDoubleQuoted $stIp)).
-      Replace('__CLUSTER_ID__', (Escape-BashDoubleQuoted $cidCluster)).
-      Replace('__NEIGHBORS__',  (Escape-BashDoubleQuoted $neighborLine))
+      Replace('__IMG__',           (Escape-BashDoubleQuoted $BenchmarkImage)).
+      Replace('__REDIS_IP__',      (Escape-BashDoubleQuoted $redisIp)).
+      Replace('__ST_IP__',         (Escape-BashDoubleQuoted $stIp)).
+      Replace('__CLUSTER_ID__',    (Escape-BashDoubleQuoted $cidCluster)).
+      Replace('__NEIGHBORS__',     (Escape-BashDoubleQuoted $neighborLine)).
+      Replace('__TICK_RATE_HZ__',  (Escape-BashDoubleQuoted ([string]$ClusterTickRateHz)))
     $clScript = $clScript -replace "`r`n", "`n"
 
     $instId = $clusterInstIds[$i]

--- a/infra/aws/topologies/AwsSpacetimeOnly/RemoteBenchmark.ps1
+++ b/infra/aws/topologies/AwsSpacetimeOnly/RemoteBenchmark.ps1
@@ -14,6 +14,9 @@ function Invoke-AwsSpacetimeOnlyRemoteBenchmark {
     [Parameter(Mandatory)][string]$BenchmarkImage,
     [string]$ContainerConfigPath = '/opt/benchmark/runtime-configs/spacetimedb_only.json',
     [Parameter(Mandatory)][string]$S3ConfigUri,
+    # Accepted for splat compatibility with the AwsArcanePerHost topology;
+    # SpacetimeDB-only mode runs no Arcane cluster, so the value is unused.
+    [int]$ClusterTickRateHz = 20,
     [int]$SsmDriverBenchmarkTimeoutSeconds = 28800
   )
 


### PR DESCRIPTION
## Summary

Closes the benchmark side of #51. The arcane infra side (env-driven `TICK_RATE_HZ` helper) landed via brainy-bots/arcane#48; submodule pointer bumped to 568c71b.

- **`benchmark-cluster`**: `BUFF_DURATION_TICKS` becomes a runtime calculation off `ctx.dt_seconds` (10 seconds wall-clock at any tick rate). New public `BUFF_DURATION_SECONDS` const + `buff_duration_ticks(dt_seconds)` helper.
- **Orchestrator**: `Run-Benchmark-Aws.ps1` reads optional `ClusterTickRateHz` from the config JSON (default 20 — preserves prior behavior) and passes it to the topology.
- **AwsArcanePerHost**: sets `BENCHMARK_TICK_RATE_HZ` on the cluster `docker run` from the new param.
- **AwsSpacetimeOnly**: accepts the param for splat compatibility but ignores it.
- **Sample config**: `configs/arcane_plus_spacetimedb.clusters_4.tick30.json` shows the field in use — 30 Hz cluster tick + 100 ms latency gate (the new MMO-class headline). The existing 20 Hz / 200 ms baseline is unchanged.

## Why

The 7,250-player ceiling at 20 Hz / 200 ms is the historical baseline. The next published headline runs at 30 Hz / 100 ms — Arcane sustains 30 Hz at scale where incumbent MMOs publish 5–20 Hz, and the framing leans into that. Making tick rate runtime-configurable removes the rebuild-per-measurement cycle.

## Test plan

- [x] `benchmark-cluster` unit tests (7) pass — buff helper, buff expiry, physics, collision.
- [x] arcane workspace tests pass (validated in brainy-bots/arcane#48 CI).
- [ ] Cloud smoke: 200-player smoke run against the new image to verify the env wires through to the cluster log `tick_rate=30Hz` line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)