### PR TITLE
Add Claude on labeled issue workflow

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -1,0 +1,34 @@
+name: Claude on labeled issue
+on:
+  issues:
+    types: [labeled]
+
+jobs:
+  claude:
+    if: github.event.label.name == 'claude-ready' && github.event.sender.login == 'martinjms'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          prompt: |
+            Pick up GitHub issue #${{ github.event.issue.number }} in this repo: "${{ github.event.issue.title }}".
+
+            Issue body:
+            ${{ github.event.issue.body }}
+
+            Working rules (override any conflicting habits):
+            - Open a pull request with your changes. Do NOT merge it; Martin reviews every PR.
+            - When you finish, comment on the issue summarizing what was done and what still remains. Do NOT close the issue.
+            - If you introduce something to replace existing code or docs, remove the old version in the same PR — do not let both live in parallel.
+            - Do not frame work by release stage (no "MVP", "v1", "post-MVP", "future"). Describe work by merit and dependencies.
+            - Follow existing project conventions. If a CLAUDE.md exists in the repo, treat its rules as binding.
+
+            Begin.


### PR DESCRIPTION
Adds `.github/workflows/claude-issue.yml` so labeling a GitHub issue with `claude-ready` triggers `anthropics/claude-code-action@v1` to pick it up.

## Behavior
- Trigger: `issues: [labeled]`, label `claude-ready`, sender `martinjms` (actor guard prevents anyone else with write access from spending Max quota).
- Auth: `secrets.CLAUDE_CODE_OAUTH_TOKEN` (already set on this repo).
- Permissions: `contents: write`, `issues: write`, `pull-requests: write`.
- Prompt encodes standing rules: open PR don't merge, comment on issue don't close, replace-don't-accumulate, no release-stage framing.

## Follow-ups (not in this PR)
- Add `issue_comment` / `pull_request_review_comment` triggers so `@claude` mentions on PRs continue the work.
- Per-repo CLAUDE.md for domain-specific rules (benchmark conventions, etc.).

## Test plan
- [ ] Merge this PR.
- [ ] Create an `claude-ready` label (auto-created by the bootstrap script alongside this PR).
- [ ] Open a small test issue, add the `claude-ready` label, watch Actions tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)