### PR TITLE
Fix: add id-token + actions permissions to claude-issue workflow

### DIFF
--- a/.github/workflows/claude-issue.yml
+++ b/.github/workflows/claude-issue.yml
@@ -11,6 +11,8 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+      id-token: write
+      actions: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
First agent run failed with `Could not fetch an OIDC token. Did you remember to add 'id-token: write' to your workflow permissions?` (run on `arcane_swarm` issue #8 — same workflow lives in all three repos so all need this fix).

Adds two permissions per the action's [canonical example workflow](https://github.com/anthropics/claude-code-action/blob/main/examples/claude.yml):

- `id-token: write` — required by `claude-code-action@v1` for OIDC token fetch even when authenticating via OAuth token.
- `actions: read` — lets Claude read CI results on PRs (recommended; not strictly required for the basic flow but trivially adds context).

Tracking: brainy-bots/arcane#54 already filed for the prompt-injection vector — independent fix; this PR is the unblocker for the workflow firing at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)