### PR TITLE
feat(controller): #77 phase / test-plan TOML schema

### DIFF
--- a/crates/benchmark-controller/src/plan.rs
+++ b/crates/benchmark-controller/src/plan.rs
@@ -7,12 +7,14 @@ use serde::{Deserialize, Serialize};
 
 /// Top-level plan: identification + ordered phases.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct TestPlan {
     pub plan: PlanMeta,
     pub phases: Vec<Phase>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 pub struct PlanMeta {
     pub name: String,
     #[serde(default)]
@@ -21,6 +23,7 @@ pub struct PlanMeta {
 
 /// One phase: target player count, ramp pacing, hold duration, optional gate.
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[serde(deny_unknown_fields)]
 pub struct Phase {
     pub name: String,
     pub target_players: u32,
@@ -32,6 +35,7 @@ pub struct Phase {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Default)]
+#[serde(deny_unknown_fields)]
 pub struct PhaseGate {
     /// Per-phase maximum p99 latency in milliseconds.
     #[serde(default)]
@@ -45,7 +49,15 @@ pub struct PhaseGate {
     pub min_entities: Option<u64>,
 }
 
-/// Parse a TOML test plan from a string. Implementation lands in #77.
-pub fn parse(_toml_text: &str) -> Result<TestPlan, String> {
-    unimplemented!("#77: parse TOML test plan — see tests/plan.rs")
+/// Parse a TOML test plan. Unknown top-level or per-section keys are
+/// rejected so configuration typos surface immediately rather than being
+/// silently ignored.
+pub fn parse(toml_text: &str) -> Result<TestPlan, String> {
+    toml::from_str::<TestPlan>(toml_text).map_err(|e| e.to_string())
+}
+
+/// Serialize a plan back to TOML. Used for round-trip stability tests and
+/// for stamping the resolved plan into the run manifest.
+pub fn serialize(plan: &TestPlan) -> Result<String, String> {
+    toml::to_string(plan).map_err(|e| e.to_string())
 }

--- a/crates/benchmark-controller/src/tests/plan.rs
+++ b/crates/benchmark-controller/src/tests/plan.rs
@@ -1,37 +1,147 @@
 //! Acceptance tests for #77 (phase / test-plan TOML schema).
-//! The tests are the spec. Implementation in `src/plan.rs` makes these pass.
+//! The tests are the spec.
+
+use crate::plan::{parse, serialize, Phase, PhaseGate, PlanMeta, TestPlan};
+
+const VALID_PLAN: &str = r#"
+[plan]
+name = "headline-13500"
+description = "13,500 CCU headline benchmark"
+
+[[phases]]
+name = "warmup"
+target_players = 1000
+spawn_delay_ms = 50
+hold_seconds = 60
+[phases.gate]
+max_p99_latency_ms = 100
+
+[[phases]]
+name = "ramp"
+target_players = 13500
+spawn_delay_ms = 25
+hold_seconds = 600
+[phases.gate]
+max_p99_latency_ms = 100
+max_error_rate = 0.01
+min_entities = 13000
+"#;
 
 #[test]
-#[ignore]
 fn parse_valid_plan_returns_typed_struct() {
-    // Acceptance: Parsing a valid TOML returns a typed `TestPlan`.
-    todo!()
+    let plan = parse(VALID_PLAN).expect("valid plan should parse");
+    assert_eq!(plan.plan.name, "headline-13500");
+    assert_eq!(plan.plan.description, "13,500 CCU headline benchmark");
+    assert_eq!(plan.phases.len(), 2);
+
+    let warmup = &plan.phases[0];
+    assert_eq!(warmup.name, "warmup");
+    assert_eq!(warmup.target_players, 1000);
+    assert_eq!(warmup.spawn_delay_ms, 50);
+    assert_eq!(warmup.hold_seconds, 60);
+    let gate = warmup.gate.as_ref().expect("warmup has a gate");
+    assert_eq!(gate.max_p99_latency_ms, Some(100));
+
+    let ramp = &plan.phases[1];
+    assert_eq!(ramp.name, "ramp");
+    assert_eq!(ramp.target_players, 13500);
+    let gate = ramp.gate.as_ref().expect("ramp has a gate");
+    assert_eq!(gate.max_p99_latency_ms, Some(100));
+    assert_eq!(gate.max_error_rate, Some(0.01));
+    assert_eq!(gate.min_entities, Some(13000));
 }
 
 #[test]
-#[ignore]
 fn parse_unknown_top_level_key_rejected_with_clear_error() {
-    // Acceptance: Parsing rejects unknown top-level keys with a clear error.
-    todo!()
+    let bad = r#"
+[plan]
+name = "x"
+
+[[phases]]
+name = "p"
+target_players = 1
+spawn_delay_ms = 1
+hold_seconds = 1
+
+[bogus_section]
+foo = 1
+"#;
+    let err = parse(bad).expect_err("unknown top-level section should be rejected");
+    assert!(
+        err.contains("bogus_section") || err.contains("unknown"),
+        "error should name the offending key; got: {}",
+        err
+    );
 }
 
 #[test]
-#[ignore]
+fn parse_unknown_phase_key_rejected() {
+    let bad = r#"
+[plan]
+name = "x"
+
+[[phases]]
+name = "p"
+target_players = 1
+spawn_delay_ms = 1
+hold_seconds = 1
+typo_field = 7
+"#;
+    let err = parse(bad).expect_err("unknown per-phase key should be rejected");
+    assert!(
+        err.contains("typo_field") || err.contains("unknown"),
+        "error should name the offending key; got: {}",
+        err
+    );
+}
+
+#[test]
 fn phases_preserve_file_order() {
-    // Acceptance: Phases are an ordered Vec<Phase>; index in the file is preserved.
-    todo!()
+    let plan = parse(VALID_PLAN).unwrap();
+    assert_eq!(plan.phases[0].name, "warmup");
+    assert_eq!(plan.phases[1].name, "ramp");
 }
 
 #[test]
-#[ignore]
 fn phase_gate_optional() {
-    // Acceptance: Per-phase `gate` is optional — phases without a gate are not evaluated.
-    todo!()
+    let no_gate = r#"
+[plan]
+name = "x"
+
+[[phases]]
+name = "p"
+target_players = 1
+spawn_delay_ms = 1
+hold_seconds = 1
+"#;
+    let plan = parse(no_gate).unwrap();
+    assert!(plan.phases[0].gate.is_none());
 }
 
 #[test]
-#[ignore]
 fn round_trip_parse_serialize_parse_is_identical() {
-    // Acceptance: parse → serialize → parse produces identical output (test fixture).
-    todo!()
+    let plan = parse(VALID_PLAN).unwrap();
+    let toml_str = serialize(&plan).expect("serialize roundtrip");
+    let plan2 = parse(&toml_str).expect("re-parse roundtrip");
+    assert_eq!(plan, plan2);
+}
+
+#[test]
+fn plan_meta_construct_from_parts_for_completeness() {
+    // Construct Phase + PlanMeta + PhaseGate by hand to flush out missed
+    // pub fields (the integration scaffolding for downstream issues uses the
+    // types directly).
+    let _ = TestPlan {
+        plan: PlanMeta {
+            name: "x".to_string(),
+            description: String::new(),
+        },
+        phases: vec![Phase {
+            name: "p".to_string(),
+            target_players: 1,
+            spawn_delay_ms: 1,
+            hold_seconds: 1,
+            gate: Some(PhaseGate::default()),
+        }],
+    };
 }


### PR DESCRIPTION
Closes [#77](https://github.com/brainy-bots/arcane-scaling-benchmarks/issues/77).

Implements \`parse\` + \`serialize\` for the \`TestPlan\` / \`Phase\` / \`PhaseGate\` types landed as scaffold in PR #84.

- \`parse\` — TOML → typed \`TestPlan\`, with errors that name the offending key
- \`serialize\` — \`TestPlan\` → TOML, used for round-trip stability tests + for stamping the resolved plan into the run manifest (#80)
- \`#[serde(deny_unknown_fields)]\` at every level so configuration typos surface immediately

## Test plan

- [x] 7 acceptance tests cover: valid parse, unknown top-level rejection, unknown per-phase rejection, file-order preservation, optional gate, round-trip stability, constructor smoke test
- [x] \`cargo test -p benchmark-controller\` — 7 passed, 14 ignored (other components)
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)