### PR TITLE
feat(controller): #79 validity gate

### DIFF
--- a/crates/benchmark-controller/src/gate.rs
+++ b/crates/benchmark-controller/src/gate.rs
@@ -1,11 +1,20 @@
 //! Validity gate (#79).
 //!
 //! Subscribes to the orchestrator's telemetry SSE stream, evaluates per-phase
-//! acceptance against the latest cluster /stats summary, and signals
+//! acceptance against the latest cluster `/stats` summary, and signals
 //! `Fail` after `breach_window` consecutive breached evaluations.
 //!
 //! Pure logic — wire transport (HTTP/SSE) is plumbed in by the controller's
 //! main loop; this module operates on already-parsed `TelemetrySnapshot`s.
+//!
+//! Axis sources from `TelemetrySnapshot`:
+//! - `max_p99_latency_ms`: derived from per-cluster `last_tick_us / 1000`
+//!   (max across clusters). This is a tick-time proxy until driver-reported
+//!   latency lands in the snapshot via a dedicated telemetry message.
+//! - `min_entities`: min of `entities_current` across clusters. Direct.
+//! - `max_error_rate`: not yet wired — the snapshot doesn't carry an
+//!   error-rate field today. Configured but ignored; lands when the driver
+//!   pushes per-tick error counters into the telemetry stream.
 
 use crate::plan::PhaseGate;
 use arcane_swarm_orchestrator::telemetry::TelemetrySnapshot;
@@ -21,11 +30,14 @@ pub enum Evaluation {
     Fail,
 }
 
-/// The gate. Stateful: tracks consecutive breach count for the active phase.
+/// The gate. Stateful: tracks consecutive breach count for the active phase
+/// plus a latched `any_phase_failed` flag used by the scheduler to refuse
+/// subsequent phases after a fail.
 pub struct ValidityGate {
     config: PhaseGate,
     breach_window: u32,
     consecutive_breaches: u32,
+    any_phase_failed: bool,
 }
 
 impl ValidityGate {
@@ -34,6 +46,7 @@ impl ValidityGate {
             config,
             breach_window: 3,
             consecutive_breaches: 0,
+            any_phase_failed: false,
         }
     }
 
@@ -42,18 +55,73 @@ impl ValidityGate {
         self
     }
 
-    /// Reset for a new phase.
-    pub fn start_phase(&mut self, _config: PhaseGate) {
-        unimplemented!("#79: phase reset — see tests/gate.rs")
+    /// Reset breach counter and load a new phase's config. Does NOT clear
+    /// the `any_phase_failed` latch — that's a run-level signal.
+    pub fn start_phase(&mut self, config: PhaseGate) {
+        self.config = config;
+        self.consecutive_breaches = 0;
     }
 
-    /// Feed one snapshot. Implementation lands in #79.
-    pub fn evaluate(&mut self, _snap: &TelemetrySnapshot) -> Evaluation {
-        let _ = (&self.config, self.breach_window, self.consecutive_breaches);
-        unimplemented!("#79: per-snapshot evaluation — see tests/gate.rs")
+    /// Feed one snapshot.
+    pub fn evaluate(&mut self, snap: &TelemetrySnapshot) -> Evaluation {
+        // No configured axis = phase auto-passes.
+        if self.config.max_p99_latency_ms.is_none()
+            && self.config.min_entities.is_none()
+            && self.config.max_error_rate.is_none()
+        {
+            return Evaluation::Pass;
+        }
+
+        let breached = self.is_breached(snap);
+        if breached {
+            self.consecutive_breaches = self.consecutive_breaches.saturating_add(1);
+            if self.consecutive_breaches >= self.breach_window {
+                self.any_phase_failed = true;
+                return Evaluation::Fail;
+            }
+            Evaluation::Pending
+        } else {
+            self.consecutive_breaches = 0;
+            Evaluation::Pass
+        }
+    }
+
+    /// True iff a prior phase has been marked Fail. Latches for the rest
+    /// of the run; the scheduler queries this to short-circuit subsequent
+    /// phases.
+    pub fn any_phase_failed(&self) -> bool {
+        self.any_phase_failed
     }
 
     pub fn consecutive_breaches(&self) -> u32 {
         self.consecutive_breaches
+    }
+
+    fn is_breached(&self, snap: &TelemetrySnapshot) -> bool {
+        if let Some(max_ms) = self.config.max_p99_latency_ms {
+            let max_tick_us = snap
+                .clusters
+                .values()
+                .map(|c| c.last_tick_us)
+                .max()
+                .unwrap_or(0);
+            if max_tick_us / 1000 > max_ms as u64 {
+                return true;
+            }
+        }
+        if let Some(min_entities) = self.config.min_entities {
+            let min_seen = snap
+                .clusters
+                .values()
+                .map(|c| c.entities_current)
+                .min()
+                .unwrap_or(u64::MAX);
+            if snap.clusters.is_empty() || min_seen < min_entities {
+                return true;
+            }
+        }
+        // max_error_rate: currently unused — see module docstring.
+        let _ = self.config.max_error_rate;
+        false
     }
 }

--- a/crates/benchmark-controller/src/tests/gate.rs
+++ b/crates/benchmark-controller/src/tests/gate.rs
@@ -1,38 +1,151 @@
 //! Acceptance tests for #79 (validity gate).
 //! The tests are the spec.
 
+use crate::gate::{Evaluation, ValidityGate};
+use crate::plan::PhaseGate;
+use arcane_swarm_orchestrator::telemetry::{ClusterWireStats, TelemetrySnapshot};
+use std::collections::HashMap;
+
+fn snap_with_tick_us(last_tick_us: u64) -> TelemetrySnapshot {
+    let mut clusters = HashMap::new();
+    clusters.insert(
+        "cluster-a".to_string(),
+        ClusterWireStats {
+            bytes_in: 0,
+            bytes_out: 0,
+            last_tick_us,
+            broadcast_lagged_events: 0,
+            entities_current: 1000,
+        },
+    );
+    TelemetrySnapshot {
+        snapshot_at_unix_ms: 0,
+        fleet: Vec::new(),
+        recent_commands: Vec::new(),
+        clusters,
+    }
+}
+
+fn snap_with_entities(entities_current: u64) -> TelemetrySnapshot {
+    let mut clusters = HashMap::new();
+    clusters.insert(
+        "cluster-a".to_string(),
+        ClusterWireStats {
+            bytes_in: 0,
+            bytes_out: 0,
+            last_tick_us: 33_000,
+            broadcast_lagged_events: 0,
+            entities_current,
+        },
+    );
+    TelemetrySnapshot {
+        snapshot_at_unix_ms: 0,
+        fleet: Vec::new(),
+        recent_commands: Vec::new(),
+        clusters,
+    }
+}
+
 #[test]
-#[ignore]
 fn phase_with_all_gates_passing_outcome_pass() {
-    // Acceptance: Phase with all gates passing → outcome `Pass`.
-    todo!()
+    let mut gate = ValidityGate::new(PhaseGate {
+        max_p99_latency_ms: Some(100),
+        max_error_rate: None,
+        min_entities: Some(500),
+    });
+    // last_tick_us = 33_000us = 33ms, well under 100ms
+    // entities_current = 1000, well over 500
+    let snap = snap_with_tick_us(33_000);
+    assert_eq!(gate.evaluate(&snap), Evaluation::Pass);
 }
 
 #[test]
-#[ignore]
-fn latency_breach_three_consecutive_outcome_fail_within_6s() {
-    // Acceptance: Phase with latency exceeding gate for 3 consecutive events
-    // → outcome `Fail` within ~6 s of breach (3 × 2 s evaluation cadence).
-    todo!()
+fn latency_breach_three_consecutive_outcome_fail_within_breach_window() {
+    let mut gate = ValidityGate::new(PhaseGate {
+        max_p99_latency_ms: Some(100),
+        max_error_rate: None,
+        min_entities: None,
+    });
+    // 200_000us = 200ms, exceeds 100ms
+    let bad = snap_with_tick_us(200_000);
+
+    assert_eq!(gate.evaluate(&bad), Evaluation::Pending); // 1
+    assert_eq!(gate.evaluate(&bad), Evaluation::Pending); // 2
+    assert_eq!(gate.evaluate(&bad), Evaluation::Fail); // 3 → fail
+    assert!(gate.any_phase_failed());
 }
 
 #[test]
-#[ignore]
 fn intermittent_breaches_do_not_fail_phase() {
-    // Acceptance: Intermittent (non-consecutive) breaches do not fail the phase.
-    todo!()
+    let mut gate = ValidityGate::new(PhaseGate {
+        max_p99_latency_ms: Some(100),
+        max_error_rate: None,
+        min_entities: None,
+    });
+    let bad = snap_with_tick_us(200_000);
+    let good = snap_with_tick_us(33_000);
+
+    for _ in 0..10 {
+        assert_eq!(gate.evaluate(&bad), Evaluation::Pending);
+        assert_eq!(gate.evaluate(&good), Evaluation::Pass);
+        // good resets the counter — never fails
+    }
+    assert!(!gate.any_phase_failed());
 }
 
 #[test]
-#[ignore]
 fn fail_phase_short_circuits_subsequent_phases() {
-    // Acceptance: Phase marked `Fail` short-circuits subsequent phases.
-    todo!()
+    // After a phase fails, any_phase_failed remains true even after
+    // start_phase resets the per-phase breach counter.
+    let mut gate = ValidityGate::new(PhaseGate {
+        max_p99_latency_ms: Some(100),
+        ..PhaseGate::default()
+    });
+    let bad = snap_with_tick_us(200_000);
+    gate.evaluate(&bad);
+    gate.evaluate(&bad);
+    gate.evaluate(&bad);
+    assert!(gate.any_phase_failed());
+
+    gate.start_phase(PhaseGate {
+        max_p99_latency_ms: Some(100),
+        ..PhaseGate::default()
+    });
+    assert_eq!(gate.consecutive_breaches(), 0);
+    assert!(
+        gate.any_phase_failed(),
+        "any_phase_failed must remain latched across start_phase"
+    );
 }
 
 #[test]
-#[ignore]
 fn missing_gate_config_phase_auto_passes() {
-    // Acceptance: Missing gate config = phase auto-passes (no evaluation).
-    todo!()
+    let mut gate = ValidityGate::new(PhaseGate::default()); // no axes set
+    let snap = snap_with_tick_us(999_999_999); // would normally breach
+    assert_eq!(gate.evaluate(&snap), Evaluation::Pass);
+    assert!(!gate.any_phase_failed());
+}
+
+#[test]
+fn min_entities_breach_counts_too() {
+    let mut gate = ValidityGate::new(PhaseGate {
+        min_entities: Some(1000),
+        ..PhaseGate::default()
+    })
+    .with_breach_window(2);
+
+    let bad = snap_with_entities(500);
+    assert_eq!(gate.evaluate(&bad), Evaluation::Pending);
+    assert_eq!(gate.evaluate(&bad), Evaluation::Fail);
+}
+
+#[test]
+fn breach_window_can_be_overridden() {
+    let mut gate = ValidityGate::new(PhaseGate {
+        max_p99_latency_ms: Some(100),
+        ..PhaseGate::default()
+    })
+    .with_breach_window(1);
+    let bad = snap_with_tick_us(200_000);
+    assert_eq!(gate.evaluate(&bad), Evaluation::Fail); // 1 breach is enough
 }


### PR DESCRIPTION
Closes [#79](https://github.com/brainy-bots/arcane-scaling-benchmarks/issues/79).

Implements the per-phase validity gate that consumes \`TelemetrySnapshot\` events and signals \`Pass\` / \`Pending\` / \`Fail\` to the scheduler. Stateful: the gate tracks \`consecutive_breaches\` per phase and a latched \`any_phase_failed\` flag.

## Axis sources from \`TelemetrySnapshot\`

- **\`max_p99_latency_ms\`** — derived from per-cluster \`last_tick_us / 1000\` (max across clusters). Tick-time proxy until driver-reported latency lands in the snapshot via a dedicated telemetry message.
- **\`min_entities\`** — min of \`entities_current\` across clusters. Direct.
- **\`max_error_rate\`** — configured but not yet wired (the snapshot doesn't carry an error-rate field today). Documented and skipped.

## Test plan

7 acceptance tests cover all 5 issue bullets + \`min_entities\` axis + \`breach_window\` override.

- [x] \`cargo test -p benchmark-controller\` — 20 passed (7 new + 13 prior), 4 ignored
- [x] \`cargo clippy --all-targets -- -D warnings\` clean
- [x] \`cargo fmt --all -- --check\` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)