### PR TITLE
feat(deployment): controller-mode AWS deployment scaffolding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,18 @@ RUN cargo build --release --manifest-path crates/benchmark-cluster/Cargo.toml \
 RUN cargo build --release --manifest-path arcane_swarm/Cargo.toml \
       --package arcane-swarm --bin arcane-swarm
 
+# arcane-swarm-orchestrator: standalone orchestrator process. Drivers connect
+# to it via WebSocket; controllers submit commands via HTTP POST and consume
+# its telemetry SSE.
+RUN cargo build --release --manifest-path arcane_swarm/Cargo.toml \
+      --package arcane-swarm-orchestrator --bin arcane-swarm-orchestrator
+
+# benchmark-controller: drives the orchestrator from a TOML test plan.
+# Operators normally run this from a laptop, but baking it into the image
+# lets us also run it on EC2 for cloud-side reproducibility tests.
+RUN cargo build --release --manifest-path crates/benchmark-controller/Cargo.toml \
+      --bin benchmark-controller
+
 # Benchmark WASM modules for the two SpacetimeDB modes. Built with `spacetime build`
 # so the output matches what the SpacetimeDB runtime expects to load.
 RUN spacetime build --module-path crates/benchmark-spacetimedb-full
@@ -85,6 +97,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 COPY --from=builder /build/arcane/target/release/arcane-manager                                         /usr/local/bin/arcane-manager
 COPY --from=builder /build/crates/benchmark-cluster/target/release/benchmark-cluster                    /usr/local/bin/benchmark-cluster
 COPY --from=builder /build/arcane_swarm/target/release/arcane-swarm                                     /usr/local/bin/arcane-swarm
+COPY --from=builder /build/arcane_swarm/target/release/arcane-swarm-orchestrator                        /usr/local/bin/arcane-swarm-orchestrator
+COPY --from=builder /build/crates/benchmark-controller/target/release/benchmark-controller              /usr/local/bin/benchmark-controller
 
 # WASM modules — stable paths consumed by benchmark-publish-module below.
 COPY --from=builder /build/crates/benchmark-spacetimedb-full/target/wasm32-unknown-unknown/release/benchmark_spacetimedb_full.wasm        /opt/modules/benchmark_spacetimedb_full.wasm

--- a/configs/arcane_plus_spacetimedb.clusters_1.local-smoke.json
+++ b/configs/arcane_plus_spacetimedb.clusters_1.local-smoke.json
@@ -1,0 +1,75 @@
+{
+  // ═══════════════════════════════════════════════════════════════════════════
+  //  arcane_plus_spacetimedb — 1-cluster LOCAL SMOKE.
+  //
+  //  Single 100-player tier for 30 seconds against a single cluster on the
+  //  operator's laptop. Sole purpose: validate that the entire benchmark
+  //  pipeline (Redis + SpacetimeDB + Arcane manager + 1 cluster + 1 driver)
+  //  runs cleanly and emits non-zero metrics — same workload knobs as the
+  //  4-cluster cloud headline (60 Hz, 1 KB user_data, burst profile) but
+  //  scaled down to laptop resources.
+  //
+  //  This is NOT a published benchmark number. It exists so we can iterate
+  //  on the code path without spending AWS money. The headline 13,500 CCU /
+  //  10.4 ms latency number requires the AWS fleet (4 c6in.2xlarge clusters
+  //  + 12 c6in.4xlarge drivers in the same VPC).
+  //
+  //  Loosened thresholds so a marginal local run doesn't fail the smoke;
+  //  we only want to catch wiring failures.
+  // ═══════════════════════════════════════════════════════════════════════════
+
+  "BenchmarkMode":      "ArcanePlusSpacetime",
+  "ArcaneClusterCount": 1,
+  "SpacetimeModule":    "benchmark-spacetimedb-persist",
+  "PhysicsEngine":      "kinematic",
+
+  // Same tick rate + payload as the headline so the per-tick wire shape is
+  // identical to the published number. Local resources won't sustain it at
+  // 13,500 players, but the 100-player floor exercises the same code path.
+  "ClusterTickRateHz":  60,
+  "UserDataBytes":      1000,
+
+  "SpacetimeHost":  "http://127.0.0.1:3000",
+  "DatabaseName":   "arcane",
+  "RedisHost":      "127.0.0.1",
+  "RedisPort":      6379,
+
+  "ArcaneManagerHost":       "127.0.0.1",
+  "ArcaneManagerPort":       8081,
+  "ArcaneClusterHosts":      [],
+  "ArcaneClusterBasePort":   8090,
+  "ArcaneClusterPortStride": 1,
+
+  // Single 100-player tier — fast to iterate on; enough load to exercise
+  // the broadcast pipeline.
+  "ArcaneCeilingStartPlayers": 100,
+  "ArcaneCeilingStep":         100,
+  "ArcaneCeilingMaxPlayers":   100,
+  "DurationSeconds":           30,
+
+  "SpacetimePersistHz": 1,
+  "PersistBatchSize":   0,
+
+  // Loose gates — wiring check, not a measurement.
+  "MaxErrRate":   0.10,
+  "MaxLatencyMs": 500,
+
+  // Canonical workload knobs (same as headline).
+  "ActionsPerSec":            2,
+  "ReadRateHz":               5,
+  "SwarmMode":                "spread",
+  "BetweenIncrementsSeconds": 1,
+  "InterSpawnDelayMs":        8,
+
+  "DriverCount": 1,
+
+  "MaxPlayersPerDriver": 200,
+
+  "BurstEnabled":          true,
+  "BurstPeriodSecs":       30,
+  "BurstCohortPercent":    20,
+  "BurstActionsPerPlayer": 10,
+  "BurstWindowMs":         500,
+  "ZoneEventPeriodSecs":   30,
+  "ZoneEventWindowMs":     500
+}

--- a/infra/aws/Run-Benchmark-Aws-Controller.ps1
+++ b/infra/aws/Run-Benchmark-Aws-Controller.ps1
@@ -1,75 +1,72 @@
 <#
 .SYNOPSIS
-  Run the benchmark via the new controller path. Reads Terraform output, launches
-  the local `benchmark-controller` binary against the in-VPC orchestrator, and
-  surfaces the controller's exit code.
+  Run the benchmark via the new controller path on AWS. Starts the support
+  fleet (Redis, SpacetimeDB, manager, clusters), starts the orchestrator on
+  the manager EC2, starts drivers in orchestrated mode, runs the local
+  benchmark-controller against the orchestrator's public HTTP API, then
+  stops everything.
 
 .DESCRIPTION
-  This is the controller-driven replacement for `Run-Benchmark-Aws.ps1`. It
-  runs the operator's `benchmark-controller` binary on the operator's laptop;
-  the controller talks to the orchestrator EC2 over WebSocket + HTTP/SSE, and
-  the orchestrator manages drivers + clusters from inside the VPC. There is
-  NO per-driver SSM fan-out — the orchestrator is the only thing the operator
-  needs to address from outside the VPC.
+  Two-phase lifecycle: this script handles the *run* phase only.
 
-  Step in the lifecycle:
     1. terraform apply  (in infra/terraform/aws_benchmark) — provisions the
-       fleet (orchestrator + drivers + clusters) with the orchestrator's HTTP
-       endpoint exposed to the operator's CIDR.
-    2. THIS SCRIPT      — runs the controller against the orchestrator; the
-       controller writes phase_*.json + manifest.json to the configured
-       results dir (and to S3 if --s3-bucket is given).
+       fleet. Pass var.benchmark_image (the dev tag) and
+       var.operator_cidr_blocks (your laptop's public IP /32).
+    2. THIS SCRIPT      — drives the run via SSM + the local controller.
     3. terraform destroy — tear down.
 
-  Old path (Run-Benchmark-Aws.ps1) still works during the transition, but
-  this is the recommended path post-controller landing.
+  Differences from Run-Benchmark-Aws.ps1:
+  - No per-tier PowerShell loop; the local benchmark-controller drives the
+    schedule against the orchestrator's HTTP API.
+  - Drivers run with --orchestrator-url instead of being driven via per-driver
+    SSM RunCommand fan-out.
+  - The orchestrator container runs alongside arcane-manager on the
+    manager EC2.
 
 .PARAMETER StatePath
   JSON produced by `terraform output -json benchmark_state` in
   infra/terraform/aws_benchmark.
 
 .PARAMETER PlanFile
-  Path to a TOML test plan (see crates/benchmark-controller/README.md for
-  schema). Example plans live under plans/.
+  Path to a TOML test plan. Sample: plans/headline-13500.toml.
 
-.PARAMETER ResultsDir
-  Local directory to write phase_*.json + manifest.json. Defaults to
-  results/runs/<timestamp>/.
+.PARAMETER BenchmarkImage
+  Pre-built benchmark image reference, e.g.
+  ghcr.io/brainy-bots/arcane-benchmark:dev-2026-05-02. Must include the
+  arcane-swarm-orchestrator + benchmark-controller binaries.
 
 .PARAMETER ControllerBinary
   Path to the benchmark-controller binary. Defaults to looking for
-  `target/release/benchmark-controller` in this repo.
+  target/release/benchmark-controller in this repo.
 
-.PARAMETER S3Bucket
-  Optional S3 bucket to upload results to (matches the artifact bucket from
-  Terraform output). When omitted, results are written locally only.
+.PARAMETER ResultsDir
+  Local directory to write phase_*.json + manifest.json. Defaults to
+  results/runs/<Environment>/<RunId>/.
 
-.PARAMETER S3Prefix
-  S3 prefix under the bucket. Defaults to `runs/<timestamp>/`.
+.PARAMETER S3UploadResults
+  Switch — if set, the controller uploads phase + manifest files to the
+  Terraform-created S3 artifact bucket under the same prefix the
+  Terraform run uses.
 #>
 
 [CmdletBinding()]
 param(
     [Parameter(Mandatory)] [string] $StatePath,
     [Parameter(Mandatory)] [string] $PlanFile,
-    [string] $ResultsDir,
+    [Parameter(Mandatory)] [string] $BenchmarkImage,
     [string] $ControllerBinary,
-    [string] $S3Bucket,
-    [string] $S3Prefix
+    [string] $ResultsDir,
+    [switch] $S3UploadResults
 )
 
 $ErrorActionPreference = 'Stop'
 
-if (-not (Test-Path $StatePath)) {
-    throw "Terraform state file not found: $StatePath"
-}
-if (-not (Test-Path $PlanFile)) {
-    throw "Plan file not found: $PlanFile"
-}
+if (-not (Test-Path $StatePath)) { throw "Terraform state file not found: $StatePath" }
+if (-not (Test-Path $PlanFile))  { throw "Plan file not found: $PlanFile" }
 
-# Resolve the controller binary.
+# Resolve controller binary.
 if (-not $ControllerBinary) {
-    $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+    $repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
     $candidate = Join-Path $repoRoot 'target/release/benchmark-controller'
     if (-not (Test-Path $candidate)) {
         $candidate = Join-Path $repoRoot 'target/debug/benchmark-controller'
@@ -80,53 +77,235 @@ if (-not $ControllerBinary) {
     $ControllerBinary = $candidate
 }
 
-# Read the orchestrator endpoint from Terraform state.
+# Read Terraform state.
 $state = Get-Content -Raw $StatePath | ConvertFrom-Json
-$orchestratorHost = $state.value.orchestrator_public_dns
-if (-not $orchestratorHost) {
-    $orchestratorHost = $state.value.orchestrator_public_ip
-}
-if (-not $orchestratorHost) {
-    throw "Terraform state does not export orchestrator_public_dns or orchestrator_public_ip. Bump infra/terraform/aws_benchmark/outputs.tf to include the orchestrator endpoint."
-}
-$orchestratorPort = if ($state.value.orchestrator_http_port) { $state.value.orchestrator_http_port } else { 8090 }
-$orchestratorUrl = "http://${orchestratorHost}:${orchestratorPort}"
+$envName = $state.Environment
+$region  = $state.Region
+$bucket  = $state.ArtifactBucket
+$prefix  = $state.ArtifactPrefix
+$runId   = (Get-Date -Format 'yyyyMMdd_HHmmss')
 
-# Default ResultsDir to a timestamped folder.
+$managerInstanceId   = $state.ManagerInstanceId
+$managerPrivateIp    = $state.ManagerPrivateIp
+$managerPublicDns    = $state.ManagerPublicDns
+$orchHttpPort        = if ($state.OrchestratorHttpPort)   { [int]$state.OrchestratorHttpPort }   else { 8090 }
+$orchDriverPort      = if ($state.OrchestratorDriverPort) { [int]$state.OrchestratorDriverPort } else { 8088 }
+$clusterIds          = @($state.ClusterIds)
+$clusterPrivateIps   = @($state.ClusterPrivateIps)
+$clusterInstanceIds  = @($state.ClusterInstanceIds)
+$driverInstanceIds   = @($state.BenchmarkInstanceIds)
+$spacetimeInstanceId = $state.SpacetimeInstanceId
+$redisInstanceId     = $state.RedisInstanceId
+
+if (-not $managerInstanceId)   { throw "State missing ManagerInstanceId — provision with arcane_per_host topology" }
+if (-not $managerPublicDns)    { throw "State missing ManagerPublicDns — bump Terraform module to expose it" }
+if ($driverInstanceIds.Count -lt 1) { throw "State has no driver instances" }
+
 if (-not $ResultsDir) {
-    $stamp = (Get-Date -Format 'yyyyMMdd-HHmmss')
-    $ResultsDir = Join-Path (Split-Path -Parent $PSScriptRoot) "../results/runs/$stamp"
-    $ResultsDir = (Resolve-Path -LiteralPath ($ResultsDir | Split-Path -Parent)).Path + '/' + (Split-Path -Leaf $ResultsDir)
+    $ResultsDir = Join-Path $PSScriptRoot "../../results/runs/$envName/$runId"
 }
 if (-not (Test-Path $ResultsDir)) {
     New-Item -ItemType Directory -Path $ResultsDir -Force | Out-Null
 }
+$ResultsDir = (Resolve-Path $ResultsDir).Path
 
-Write-Host "==> orchestrator: $orchestratorUrl"
-Write-Host "==> plan:         $PlanFile"
-Write-Host "==> results dir:  $ResultsDir"
-if ($S3Bucket) {
-    Write-Host "==> s3:           s3://$S3Bucket/$S3Prefix"
+Write-Host "==> environment:        $envName"
+Write-Host "==> manager:            $managerInstanceId ($managerPublicDns / $managerPrivateIp)"
+Write-Host "==> clusters:           $($clusterInstanceIds.Count)"
+Write-Host "==> drivers:            $($driverInstanceIds.Count)"
+Write-Host "==> image:              $BenchmarkImage"
+Write-Host "==> orchestrator URL:   http://${managerPublicDns}:${orchHttpPort}"
+Write-Host "==> results dir:        $ResultsDir"
+
+function Invoke-Ssm {
+    param(
+        [Parameter(Mandatory)] [string]   $InstanceId,
+        [Parameter(Mandatory)] [string[]] $Commands,
+        [string] $Comment = ""
+    )
+    $cmdJson = ($Commands | ConvertTo-Json -Compress)
+    $resp = aws ssm send-command `
+        --region $region `
+        --instance-ids $InstanceId `
+        --document-name "AWS-RunShellScript" `
+        --parameters "commands=$cmdJson" `
+        --comment $Comment `
+        --output json
+    if ($LASTEXITCODE -ne 0) { throw "ssm send-command failed for $InstanceId" }
+    $cmdId = ($resp | ConvertFrom-Json).Command.CommandId
+    return $cmdId
 }
+
+function Wait-Ssm {
+    param(
+        [Parameter(Mandatory)] [string] $CommandId,
+        [Parameter(Mandatory)] [string] $InstanceId,
+        [int] $TimeoutSec = 300
+    )
+    $deadline = (Get-Date).AddSeconds($TimeoutSec)
+    while ((Get-Date) -lt $deadline) {
+        $r = aws ssm get-command-invocation --region $region --command-id $CommandId --instance-id $InstanceId --output json 2>$null | ConvertFrom-Json
+        if ($r -and $r.Status -in @('Success','Failed','Cancelled','TimedOut')) {
+            return $r
+        }
+        Start-Sleep -Seconds 3
+    }
+    throw "SSM command $CommandId on $InstanceId timed out after ${TimeoutSec}s"
+}
+
+# ── 1. Pull image on every node + start support containers ───────────────────
+$startSupport = @"
+set -euo pipefail
+docker pull $BenchmarkImage
+"@
+
+Write-Host "==> pulling image on all nodes"
+$pullCmds = @{}
+foreach ($id in @($managerInstanceId) + $clusterInstanceIds + $driverInstanceIds + @($spacetimeInstanceId, $redisInstanceId)) {
+    if (-not $id) { continue }
+    $pullCmds[$id] = Invoke-Ssm -InstanceId $id -Commands @($startSupport) -Comment "docker pull $BenchmarkImage"
+}
+foreach ($id in $pullCmds.Keys) { Wait-Ssm -CommandId $pullCmds[$id] -InstanceId $id -TimeoutSec 600 | Out-Null }
+
+# ── 2. Start Redis + SpacetimeDB + publish module ────────────────────────────
+Write-Host "==> starting Redis"
+$redisStart = @"
+set -euo pipefail
+docker rm -f bench-redis 2>/dev/null || true
+docker run -d --name bench-redis --restart unless-stopped --network host redis:7-alpine redis-server --appendonly yes
+"@
+Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $redisInstanceId -Commands @($redisStart) -Comment "redis") -InstanceId $redisInstanceId | Out-Null
+
+Write-Host "==> starting SpacetimeDB + publishing module"
+$stStart = @"
+set -euo pipefail
+docker rm -f bench-spacetime 2>/dev/null || true
+docker run -d --name bench-spacetime --restart unless-stopped --network host $BenchmarkImage spacetime start
+for i in {1..60}; do bash -c 'echo > /dev/tcp/127.0.0.1/3000' 2>/dev/null && break; sleep 2; done
+docker run --rm --network host $BenchmarkImage benchmark-publish-module --mode Persist --host http://127.0.0.1:3000
+"@
+Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $spacetimeInstanceId -Commands @($stStart) -Comment "spacetime+publish") -InstanceId $spacetimeInstanceId -TimeoutSec 600 | Out-Null
+
+# ── 3. Start cluster fleet ───────────────────────────────────────────────────
+$redisHost     = (aws ec2 describe-instances --region $region --instance-ids $redisInstanceId --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text 2>$null)
+$spacetimeHost = (aws ec2 describe-instances --region $region --instance-ids $spacetimeInstanceId --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text 2>$null)
+
+Write-Host "==> starting clusters (Redis=$redisHost, SpacetimeDB=$spacetimeHost)"
+for ($i = 0; $i -lt $clusterInstanceIds.Count; $i++) {
+    $cid     = $clusterInstanceIds[$i]
+    $cuid    = $clusterIds[$i]
+    $clusPort = 8090
+    $clStart = @"
+set -euo pipefail
+docker rm -f bench-cluster 2>/dev/null || true
+docker run -d --name bench-cluster --restart unless-stopped --network host \
+  -e CLUSTER_ID=$cuid \
+  -e REDIS_URL=redis://${redisHost}:6379 \
+  -e CLUSTER_WS_PORT=$clusPort \
+  -e SPACETIMEDB_URI=http://${spacetimeHost}:3000 \
+  -e SPACETIMEDB_DATABASE=arcane \
+  -e SPACETIMEDB_PERSIST=1 \
+  -e SPACETIMEDB_PERSIST_HZ=1 \
+  $BenchmarkImage benchmark-cluster
+"@
+    $cmdId = Invoke-Ssm -InstanceId $cid -Commands @($clStart) -Comment "cluster $i"
+    Wait-Ssm -CommandId $cmdId -InstanceId $cid | Out-Null
+}
+
+# ── 4. Start manager + orchestrator on the manager EC2 ───────────────────────
+Write-Host "==> starting manager + orchestrator on $managerInstanceId"
+
+# Build MANAGER_CLUSTERS string (uuid:host:port) for arcane-manager.
+$managerClusters = @()
+for ($i = 0; $i -lt $clusterIds.Count; $i++) {
+    $managerClusters += ("{0}:{1}:8090" -f $clusterIds[$i], $clusterPrivateIps[$i])
+}
+$managerClustersStr = ($managerClusters -join ',')
+# Stats URL list for the orchestrator.
+$statsUrls = @($clusterPrivateIps | ForEach-Object { "http://${_}:8091/stats" })
+$statsArgs = ($statsUrls | ForEach-Object { "--cluster-stats-url $_" }) -join ' '
+
+$mgrStart = @"
+set -euo pipefail
+docker rm -f bench-manager bench-orchestrator 2>/dev/null || true
+
+docker run -d --name bench-manager --restart unless-stopped --network host \
+  -e MANAGER_HTTP_PORT=8081 \
+  -e MANAGER_CLUSTERS='$managerClustersStr' \
+  $BenchmarkImage arcane-manager
+
+mkdir -p /var/orchestrator
+docker run -d --name bench-orchestrator --restart unless-stopped --network host \
+  -v /var/orchestrator:/var/orchestrator \
+  $BenchmarkImage arcane-swarm-orchestrator \
+    --driver-port $orchDriverPort \
+    --http-port $orchHttpPort \
+    --archive-dir /var/orchestrator/snapshots \
+    --max-drivers 32 \
+    $statsArgs
+"@
+Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $managerInstanceId -Commands @($mgrStart) -Comment "manager+orchestrator") -InstanceId $managerInstanceId | Out-Null
+
+# ── 5. Start drivers in orchestrated mode ────────────────────────────────────
+Write-Host "==> starting $($driverInstanceIds.Count) drivers in orchestrated mode"
+$orchUrlInternal = "ws://${managerPrivateIp}:${orchDriverPort}"
+foreach ($did in $driverInstanceIds) {
+    $drvStart = @"
+set -euo pipefail
+docker rm -f bench-driver 2>/dev/null || true
+docker run -d --name bench-driver --restart unless-stopped --network host \
+  -e ORCHESTRATOR_URL=$orchUrlInternal \
+  $BenchmarkImage arcane-swarm \
+    --backend arcane \
+    --arcane-manager http://${managerPrivateIp}:8081 \
+    --orchestrator-url $orchUrlInternal \
+    --tick-rate 60 \
+    --max-players 4000 \
+    --user-data-bytes 1000 \
+    --inter-spawn-delay-ms 8 \
+    --max-players-per-driver 4000 \
+    --burst-enabled --burst-period-secs 30 --burst-cohort-percent 20 \
+    --burst-actions-per-player 10 --burst-window-ms 500 \
+    --zone-event-period-secs 30 --zone-event-window-ms 500 \
+    --actions-per-sec 2 --read-rate 5 \
+    --run-forever
+"@
+    Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $did -Commands @($drvStart) -Comment "driver") -InstanceId $did | Out-Null
+}
+
+# Give drivers a moment to register with the orchestrator.
+Start-Sleep -Seconds 8
+
+# ── 6. Run the controller from the operator's laptop ─────────────────────────
+$orchUrlPublic = "http://${managerPublicDns}:${orchHttpPort}"
+Write-Host "==> running controller against $orchUrlPublic"
 
 $ctlArgs = @(
-    '--plan', $PlanFile,
-    '--orchestrator-url', $orchestratorUrl,
-    '--results-dir', $ResultsDir,
-    '--submitter', "operator-$env:USERNAME"
+    '--plan',             $PlanFile,
+    '--orchestrator-url', $orchUrlPublic,
+    '--results-dir',      $ResultsDir,
+    '--submitter',        "operator-$env:USERNAME"
 )
-if ($S3Bucket) {
-    $ctlArgs += '--s3-bucket', $S3Bucket
-    if ($S3Prefix) { $ctlArgs += '--s3-prefix', $S3Prefix }
+if ($S3UploadResults) {
+    $ctlArgs += '--s3-bucket', $bucket
+    $ctlArgs += '--s3-prefix', "${prefix}/${envName}/${runId}/"
 }
 
-Write-Host "==> launching: $ControllerBinary $($ctlArgs -join ' ')"
 & $ControllerBinary @ctlArgs
-$exitCode = $LASTEXITCODE
+$ctlExit = $LASTEXITCODE
 
-if ($exitCode -eq 0) {
+# ── 7. Stop driver + orchestrator + cluster + support containers ─────────────
+Write-Host "==> stopping all containers"
+$stopAll = "docker rm -f bench-driver bench-orchestrator bench-manager bench-cluster bench-spacetime bench-redis 2>/dev/null || true"
+$allInstances = @($managerInstanceId) + $clusterInstanceIds + $driverInstanceIds + @($spacetimeInstanceId, $redisInstanceId) | Where-Object { $_ }
+foreach ($id in $allInstances) {
+    $null = Invoke-Ssm -InstanceId $id -Commands @($stopAll) -Comment "stop"
+}
+
+Write-Host ""
+if ($ctlExit -eq 0) {
     Write-Host "==> controller exited 0 (overall PASS)" -ForegroundColor Green
 } else {
-    Write-Host "==> controller exited $exitCode (overall FAIL or error)" -ForegroundColor Red
+    Write-Host "==> controller exited $ctlExit (overall FAIL or error)" -ForegroundColor Red
 }
-exit $exitCode
+exit $ctlExit

--- a/infra/terraform/aws_benchmark/arcaneperhost.clusters_4.drivers_12.tfvars
+++ b/infra/terraform/aws_benchmark/arcaneperhost.clusters_4.drivers_12.tfvars
@@ -1,19 +1,19 @@
-aws_region                = "us-east-1"
-topology                  = "AwsArcanePerHost"
-arcane_cluster_count      = 4
-arph_driver_count         = 12
+aws_region           = "us-east-1"
+topology             = "AwsArcanePerHost"
+arcane_cluster_count = 4
+arph_driver_count    = 12
 
 # Keep cluster nodes NIC-optimized for this A/B phase.
-instance_type             = "c6in.2xlarge"
+instance_type = "c6in.2xlarge"
 
 # Driver remains NIC-optimized and high-core.
 arph_driver_instance_type = "c6in.4xlarge"
 
 # Data-plane sidecars unchanged from prior successful runs.
-data_instance_type        = "t3.large"
-redis_instance_type       = "c5n.large"
+data_instance_type  = "t3.large"
+redis_instance_type = "c5n.large"
 
-root_volume_gib           = 100
-artifact_prefix           = "benchmark-aws"
-remote_provision_profile  = "Full"
-s3_bucket_force_destroy   = true
+root_volume_gib          = 100
+artifact_prefix          = "benchmark-aws"
+remote_provision_profile = "Full"
+s3_bucket_force_destroy  = true

--- a/infra/terraform/aws_benchmark/networking.tf
+++ b/infra/terraform/aws_benchmark/networking.tf
@@ -6,8 +6,8 @@ data "aws_availability_zones" "available" {
 resource "aws_vpc" "bench" {
   count                = var.subnet_id == "" ? 1 : 0
   cidr_block           = "10.0.0.0/24"
-  enable_dns_support   = true  # Preserve default VPC behavior (required for DNS resolution)
-  enable_dns_hostnames = true  # Preserve default VPC behavior (enables EC2 public DNS hostnames)
+  enable_dns_support   = true # Preserve default VPC behavior (required for DNS resolution)
+  enable_dns_hostnames = true # Preserve default VPC behavior (enables EC2 public DNS hostnames)
 
   tags = {
     Name      = "arcane-bench-tf"

--- a/infra/terraform/aws_benchmark/outputs.tf
+++ b/infra/terraform/aws_benchmark/outputs.tf
@@ -28,9 +28,20 @@ locals {
     ArphDriverCount      = local.is_arph ? var.arph_driver_count : 0
     RedisInstanceId      = local.is_arph ? try(aws_instance.arph_redis[0].id, null) : null
     ManagerInstanceId    = local.is_arph ? try(aws_instance.arph_manager[0].id, null) : null
+    ManagerPublicDns     = local.is_arph ? try(aws_instance.arph_manager[0].public_dns, null) : null
+    ManagerPublicIp      = local.is_arph ? try(aws_instance.arph_manager[0].public_ip, null) : null
+    ManagerPrivateIp     = local.is_arph ? try(aws_instance.arph_manager[0].private_ip, null) : null
     ClusterInstanceIds   = local.is_arph ? [for i in aws_instance.arph_cluster : i.id] : []
+    ClusterPrivateIps    = local.is_arph ? [for i in aws_instance.arph_cluster : i.private_ip] : []
     ClusterIds           = local.is_arph ? [for u in random_uuid.cluster : u.result] : []
     MaxArcaneClusters    = local.is_arph ? var.arcane_cluster_count : 0
+    # Orchestrator endpoint — the benchmark-controller (operator's laptop)
+    # connects here for command submission + telemetry SSE. The orchestrator
+    # process runs on the manager EC2 alongside arcane-manager. Drivers reach
+    # it via ManagerPrivateIp + OrchestratorDriverPort over the VPC.
+    OrchestratorPublicDns  = local.is_arph ? try(aws_instance.arph_manager[0].public_dns, null) : null
+    OrchestratorHttpPort   = 8090
+    OrchestratorDriverPort = 8088
   }
 }
 

--- a/infra/terraform/aws_benchmark/security_groups.tf
+++ b/infra/terraform/aws_benchmark/security_groups.tf
@@ -3,7 +3,8 @@ locals {
     { from = 6379, to = 6379 },
     { from = 3000, to = 3000 },
     { from = 8081, to = 8081 },
-    { from = 8090, to = 8110 },
+    { from = 8088, to = 8088 }, # orchestrator driver-WS
+    { from = 8090, to = 8110 }, # cluster WS + orchestrator HTTP API
   ]
 }
 
@@ -33,6 +34,24 @@ resource "aws_security_group" "bench" {
       self        = true
     }
   }
+
+  # Orchestrator HTTP API (controller submission + telemetry SSE) reachable
+  # from the operator's CIDR. The orchestrator process binds 0.0.0.0:8090
+  # on the manager EC2; the security group is the actual access control.
+  dynamic "ingress" {
+    for_each = local.is_arph && length(var.operator_cidr_blocks) > 0 ? [1] : []
+    content {
+      description = "Orchestrator HTTP API for controller (AwsArcanePerHost)"
+      from_port   = 8090
+      to_port     = 8090
+      protocol    = "tcp"
+      cidr_blocks = var.operator_cidr_blocks
+    }
+  }
+
+  # Orchestrator driver-WS port — internal-only (drivers reach it via the
+  # manager's private IP). Already covered by the 8090-8110 self-rule above
+  # at port 8088, so nothing extra here.
 
   egress {
     from_port   = 0

--- a/infra/terraform/aws_benchmark/variables.tf
+++ b/infra/terraform/aws_benchmark/variables.tf
@@ -115,3 +115,9 @@ variable "s3_bucket_force_destroy" {
   description = "When true, terraform destroy can delete a non-empty artifact bucket. Leave true so destroy always tears down cleanly for reproducibility."
   default     = true
 }
+
+variable "operator_cidr_blocks" {
+  type        = list(string)
+  description = "CIDR blocks allowed to reach the orchestrator's HTTP API (port 8090) on the manager EC2. The benchmark controller runs from the operator's laptop and connects over the public internet to this endpoint. Empty list = no external access (orchestrator is internal-only). Set to your laptop's public IP /32 for a controller run."
+  default     = []
+}


### PR DESCRIPTION
Wires the new controller architecture into the existing AWS benchmark infrastructure. Operators can now run a controller-driven benchmark on the same provisioned fleet pattern they use today.

## What changed

**Dockerfile** — bake the new \`arcane-swarm-orchestrator\` and \`benchmark-controller\` binaries into the published image alongside the existing \`arcane-manager\` / \`benchmark-cluster\` / \`arcane-swarm\`.

**Terraform** (\`infra/terraform/aws_benchmark/\`):
- \`security_groups.tf\` — open port 8090 from \`var.operator_cidr_blocks\` for the controller's HTTP API; ports 8088 + 8090 inside the VPC for driver↔orchestrator + cluster /stats.
- \`variables.tf\` — new \`var.operator_cidr_blocks\` (laptop's public IP /32).
- \`outputs.tf\` — expose \`ManagerPublicDns\` / \`ManagerPrivateIp\` / \`ClusterPrivateIps\` / \`OrchestratorHttpPort\` / \`OrchestratorDriverPort\`.

**\`infra/aws/Run-Benchmark-Aws-Controller.ps1\`** (rewritten) — full controller-mode launcher:
1. Reads Terraform state
2. Pulls the dev image on every node
3. Starts Redis + SpacetimeDB (publishes the WASM module)
4. Starts each cluster
5. Starts \`arcane-manager\` + \`arcane-swarm-orchestrator\` containers on the manager EC2
6. Starts each driver in orchestrated mode (\`--orchestrator-url ws://manager-private-ip:8088\`)
7. Runs the local \`benchmark-controller\` binary against the manager's PUBLIC DNS
8. Stops every container on exit

**Submodule bump** — \`arcane_swarm → adcf03d\` (latest main; includes the orchestrator binary).

## Tested

- \`terraform validate\` / \`terraform fmt\` clean against the updated config
- Local \`benchmark-controller\` binary still works (\`full_loop_e2e\` + 25 unit tests pass)

## Out of scope (intentional follow-ups)

- Docker image build + push to GHCR with a dev tag (the deployment phase Martin and I separated mid-session)
- \`terraform apply\` against a real AWS account + first end-to-end run (the benchmark / money-spending phase)

This PR is the **code+config gate**; everything in this PR is reversible with a \`git revert\`. The next phase (image push + AWS run) is the real-money gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)