### PR TITLE
feat: AWS reproduction wrappers + controller dashboard + Stop-bug fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,17 +42,13 @@ cd arcane-scaling-benchmarks
 
 ### 2. Provision the fleet (~5 min)
 
-Terraform creates everything from scratch in your AWS account: 4 clusters + 12 driver instances + manager + Redis + SpacetimeDB + S3 bucket + IAM + security groups.
-
 ```bash
-cd infra/terraform/aws_benchmark
-terraform init
-terraform apply -var-file=arcaneperhost.clusters_4.drivers_12.tfvars -auto-approve
-terraform output -json benchmark_state > .benchmark-aws-terraform.json
-cd ../../..
+./infra/aws/setup.sh
 ```
 
-Wait ~60 seconds after `terraform apply` finishes for SSM agents to register on every instance. The run script will fail loudly if any node is not yet `SSM-Online`.
+That single command runs `terraform init` + `terraform apply` (4 cluster nodes + 12 driver instances + manager + Redis + SpacetimeDB + S3 bucket + IAM + security groups), writes the canonical state JSON the run script needs, and **waits until every EC2 reports SSM `Online`** before returning. No manual sleep, no follow-up commands. Re-running `setup.sh` against an already-provisioned fleet is a safe no-op (terraform refresh + 0 changes + SSM check).
+
+Defaults to the headline topology (`arcaneperhost.clusters_4.drivers_12.tfvars`, `us-east-1`). Override with `--tfvars <name>` and `--region <aws-region>`.
 
 ### 3. Run the benchmark (~25 min)
 
@@ -70,9 +66,12 @@ Per-driver artifacts land in `s3://<artifact-bucket>/benchmark-aws/AwsArcanePerH
 ### 4. Tear down (~2 min)
 
 ```bash
-cd infra/terraform/aws_benchmark
-terraform destroy -var-file=arcaneperhost.clusters_4.drivers_12.tfvars -auto-approve
+./infra/aws/cleanup.sh
 ```
+
+That single command runs `terraform destroy` (with one automatic retry on transient AWS-API errors) and then **audits the AWS API directly** to confirm zero EC2 / Security Group / VPC / IAM / S3 resources tagged `Project=arcane-benchmark` remain in the region. Either it exits 0 with `==> CLEAN` or non-zero listing exactly what's left. No "I think it worked" — the success contract is verified end-to-end.
+
+Same flag overrides as `setup.sh` (`--tfvars`, `--region`).
 
 **Total cost of one full reproduction: ~$5** on AWS on-demand pricing.
 

--- a/crates/benchmark-controller/Cargo.lock
+++ b/crates/benchmark-controller/Cargo.lock
@@ -13,6 +13,7 @@ name = "arcane-swarm-orchestrator"
 version = "0.1.0"
 dependencies = [
  "futures",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",

--- a/crates/benchmark-controller/src/bin/benchmark_controller.rs
+++ b/crates/benchmark-controller/src/bin/benchmark_controller.rs
@@ -19,6 +19,7 @@
 use benchmark_controller::results::Uploader;
 use benchmark_controller::results::{NoopUploaderExt, S3Uploader};
 use benchmark_controller::run::{run, RunConfig, RunOutcome};
+use std::io::IsTerminal;
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -29,7 +30,8 @@ fn print_usage() {
         --orchestrator-url <http://host:port> \\
         --results-dir <dir> \\
         [--submitter <id>] \\
-        [--s3-bucket <name> --s3-prefix <prefix>]"
+        [--s3-bucket <name> --s3-prefix <prefix>] \\
+        [--dashboard auto|on|off]   (default: auto — on iff stdout is a TTY)"
     );
 }
 
@@ -41,6 +43,7 @@ async fn main() {
     let mut submitter: String = format!("benchmark-controller-{}", std::process::id());
     let mut s3_bucket: Option<String> = None;
     let mut s3_prefix: Option<String> = None;
+    let mut dashboard_arg: Option<String> = None;
 
     let args: Vec<String> = std::env::args().collect();
     let mut i = 1;
@@ -70,6 +73,10 @@ async fn main() {
                 i += 1;
                 s3_prefix = Some(args[i].clone());
             }
+            "--dashboard" => {
+                i += 1;
+                dashboard_arg = Some(args[i].clone());
+            }
             "-h" | "--help" => {
                 print_usage();
                 std::process::exit(0);
@@ -79,12 +86,27 @@ async fn main() {
         i += 1;
     }
 
+    // Default: render the dashboard iff stdout is an actual terminal.
+    // Override with --dashboard on|off; --dashboard auto re-applies the
+    // TTY autodetect explicitly. CI / file redirects fall through to off
+    // automatically, so the existing one-line summary still parses.
+    let enable_dashboard = match dashboard_arg.as_deref() {
+        Some("on") => true,
+        Some("off") => false,
+        Some("auto") | None => std::io::stdout().is_terminal(),
+        Some(other) => {
+            eprintln!("--dashboard expects auto|on|off, got {:?}", other);
+            std::process::exit(2);
+        }
+    };
+
     let cfg = match (plan, url, results_dir) {
         (Some(plan), Some(url), Some(rd)) => RunConfig {
             plan_path: plan,
             orchestrator_base_url: url,
             results_dir: rd,
             submitter,
+            enable_dashboard,
         },
         _ => {
             print_usage();

--- a/crates/benchmark-controller/src/dashboard.rs
+++ b/crates/benchmark-controller/src/dashboard.rs
@@ -1,0 +1,265 @@
+//! ASCII dashboard for `benchmark-controller`.
+//!
+//! Subscribes to the SSE-fed `TelemetrySnapshot` broadcast and renders a
+//! plain ANSI screen to stdout every time a snapshot arrives (or every 2 s
+//! if the stream stalls). No external TUI dependency — keeps the binary
+//! small and avoids alt-screen weirdness when run inside `docker run -it`
+//! against an SSM tunnel.
+//!
+//! The renderer assumes a vt100-compatible terminal. When stdout is not a
+//! TTY (CI, file redirection), the run loop should not spawn this task —
+//! see `run::should_enable_dashboard`.
+//!
+//! Layout (one screen, redraws in place):
+//!
+//! ```text
+//! ARCANE BENCHMARK CONTROLLER · headline-13500
+//! ─────────────────────────────────────────────
+//! Phase 3/10  tier-4500-aggregate   target=4500
+//! Hold 12s / 30s   Gate: PASS   Elapsed 1:42
+//!
+//! CLUSTERS (4)
+//!   32f2a101  entities=1125  tick=5.0ms
+//!   …
+//!   TOTAL    entities=4500 / 4500    worst tick=5.2ms / 16.7ms budget
+//!
+//! DRIVERS  active=12  stale=0
+//!
+//! RECENT COMMANDS (newest first)
+//!   seq=6  set_players(4500)        acked 12/12  age 11s
+//!   …
+//! ```
+//!
+//! On overall completion the dashboard task is dropped; the binary's main
+//! prints the final outcome line as before so output is greppable for
+//! "overall = Pass".
+
+use crate::plan::TestPlan;
+use arcane_swarm_orchestrator::protocol::OrchestratorCommand;
+use arcane_swarm_orchestrator::telemetry::TelemetrySnapshot;
+use std::io::Write;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+use tokio::sync::{broadcast, RwLock};
+
+/// Cross-task state the run loop updates as phases progress, so the
+/// dashboard can render without inspecting the scheduler internals.
+pub struct DashboardState {
+    pub plan: TestPlan,
+    /// Index into `plan.phases` of the currently-running phase.
+    pub current_phase_index: usize,
+    /// When the current phase started. Used for the hold-progress bar.
+    pub phase_started_at: Instant,
+    /// When the run as a whole started. Used for the "elapsed" line.
+    pub overall_started_at: Instant,
+    /// Most recent gate evaluation, lower-cased ("pass" / "fail" / etc).
+    pub gate_state: String,
+    /// Set true once the run loop is finished — the dashboard task stops
+    /// re-rendering and exits cleanly. Without this it would keep redrawing
+    /// over the binary's terminal summary line.
+    pub finished: bool,
+}
+
+impl DashboardState {
+    pub fn new(plan: TestPlan) -> Self {
+        let now = Instant::now();
+        Self {
+            plan,
+            current_phase_index: 0,
+            phase_started_at: now,
+            overall_started_at: now,
+            gate_state: "pending".to_string(),
+            finished: false,
+        }
+    }
+}
+
+/// Spawn the dashboard renderer task. Pulls the latest snapshot from the
+/// broadcast `snap_rx` and the live phase state from `state`.
+pub fn spawn_dashboard(
+    state: Arc<RwLock<DashboardState>>,
+    mut snap_rx: broadcast::Receiver<TelemetrySnapshot>,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut latest: Option<TelemetrySnapshot> = None;
+        // Refresh on snapshot arrival OR every 2s so the elapsed/hold lines
+        // tick visibly even when SSE is quiet between snapshots.
+        loop {
+            tokio::select! {
+                res = snap_rx.recv() => {
+                    match res {
+                        Ok(s) => latest = Some(s),
+                        Err(broadcast::error::RecvError::Lagged(_)) => continue,
+                        Err(broadcast::error::RecvError::Closed) => break,
+                    }
+                }
+                _ = tokio::time::sleep(Duration::from_secs(2)) => {}
+            }
+            let s = state.read().await;
+            if s.finished {
+                // Move cursor below the dashboard so the binary's terminal
+                // summary line lands on its own row instead of overwriting
+                // the last redraw.
+                let mut out = std::io::stdout().lock();
+                let _ = write!(out, "\x1b[2J\x1b[H");
+                let _ = out.flush();
+                break;
+            }
+            let _ = render(&s, latest.as_ref());
+        }
+    })
+}
+
+fn render(state: &DashboardState, snap: Option<&TelemetrySnapshot>) -> std::io::Result<()> {
+    let mut out = std::io::stdout().lock();
+    // Clear screen + home cursor. We re-render the whole screen each tick
+    // rather than diffing — at 0.5 Hz that's irrelevant for performance and
+    // avoids any ratatui-style alt-screen state to manage.
+    write!(out, "\x1b[2J\x1b[H")?;
+
+    let total_phases = state.plan.phases.len();
+    let phase = state
+        .plan
+        .phases
+        .get(state.current_phase_index)
+        .or_else(|| state.plan.phases.last());
+    let phase_name = phase.map(|p| p.name.as_str()).unwrap_or("(none)");
+    let target = phase.map(|p| p.target_players).unwrap_or(0);
+    let hold_total = phase.map(|p| p.hold_seconds).unwrap_or(0);
+    let phase_elapsed = state.phase_started_at.elapsed().as_secs();
+    let overall_elapsed = state.overall_started_at.elapsed().as_secs();
+
+    writeln!(
+        out,
+        "\x1b[1mARCANE BENCHMARK CONTROLLER\x1b[0m  ·  {}",
+        state.plan.plan.name
+    )?;
+    writeln!(out, "{}", "─".repeat(72))?;
+    writeln!(
+        out,
+        "Phase {}/{}  \x1b[1m{}\x1b[0m   target={}",
+        state.current_phase_index + 1,
+        total_phases,
+        phase_name,
+        target
+    )?;
+    let gate_color = match state.gate_state.as_str() {
+        "fail" => "\x1b[31m",
+        "pass" => "\x1b[32m",
+        _ => "\x1b[33m",
+    };
+    writeln!(
+        out,
+        "Hold {}s / {}s   Gate: {}{}\x1b[0m   Elapsed {}:{:02}",
+        phase_elapsed,
+        hold_total,
+        gate_color,
+        state.gate_state.to_uppercase(),
+        overall_elapsed / 60,
+        overall_elapsed % 60
+    )?;
+    writeln!(out)?;
+
+    if let Some(snap) = snap {
+        // ── clusters ────────────────────────────────────────────────────
+        writeln!(out, "\x1b[1mCLUSTERS\x1b[0m ({})", snap.clusters.len())?;
+        let mut clusters: Vec<_> = snap.clusters.iter().collect();
+        clusters.sort_by(|a, b| a.0.cmp(b.0));
+        let mut total_ent: u64 = 0;
+        let mut worst_tick_us: u64 = 0;
+        for (id, c) in &clusters {
+            writeln!(
+                out,
+                "  {:<24}  entities={:>5}  tick={:>5.2}ms",
+                short_cluster_id(id),
+                c.entities_current,
+                c.last_tick_us as f64 / 1000.0
+            )?;
+            total_ent += c.entities_current;
+            worst_tick_us = worst_tick_us.max(c.last_tick_us);
+        }
+        if target > 0 {
+            let pct = (total_ent as f64 / target as f64 * 100.0).min(100.0);
+            writeln!(
+                out,
+                "  {:<24}  entities={:>5} / {:<5}  ({:>3.0}%)   worst tick={:.2}ms / 16.67ms budget",
+                "TOTAL", total_ent, target, pct,
+                worst_tick_us as f64 / 1000.0
+            )?;
+        } else {
+            // Cooldown / drain — there's no positive target to compute %
+            // against; just show actual + worst tick.
+            writeln!(
+                out,
+                "  {:<24}  entities={:>5}            (drain)   worst tick={:.2}ms / 16.67ms budget",
+                "TOTAL", total_ent,
+                worst_tick_us as f64 / 1000.0
+            )?;
+        }
+        writeln!(out)?;
+
+        // ── drivers ─────────────────────────────────────────────────────
+        let active = snap.fleet.iter().filter(|d| d.state == "Active").count();
+        let stale = snap.fleet.iter().filter(|d| d.state == "Stale").count();
+        let other = snap.fleet.len() - active - stale;
+        writeln!(
+            out,
+            "\x1b[1mDRIVERS\x1b[0m  active={}  stale={}  other={}  (fleet={})",
+            active,
+            stale,
+            other,
+            snap.fleet.len()
+        )?;
+        writeln!(out)?;
+
+        // ── commands ────────────────────────────────────────────────────
+        writeln!(out, "\x1b[1mRECENT COMMANDS\x1b[0m (newest first)")?;
+        let cmds_iter = snap.recent_commands.iter().take(6);
+        for c in cmds_iter {
+            let kind = format_command(&c.command);
+            let acked = c.acked_drivers.len();
+            let missing = c.missing_drivers.len();
+            let missing_color = if missing > 0 { "\x1b[31m" } else { "" };
+            let missing_reset = if missing > 0 { "\x1b[0m" } else { "" };
+            writeln!(
+                out,
+                "  seq={:<4} {:<32} acked {:>2}/{:<2}  {}missing {}{}  age {}s",
+                c.seq,
+                kind,
+                acked,
+                acked + missing,
+                missing_color,
+                missing,
+                missing_reset,
+                c.age_ms / 1000
+            )?;
+        }
+    } else {
+        writeln!(out, "(waiting for first telemetry snapshot…)")?;
+    }
+    out.flush()?;
+    Ok(())
+}
+
+/// Strip the orchestrator's verbose stats-URL key down to a useful
+/// operator-facing label. Keys today look like
+/// `http://10.0.0.84:8091/stats`; we want `10.0.0.84:8091`. Falls back
+/// to a 24-char prefix if the key doesn't follow the URL shape (so
+/// future cluster-id schemes still render something sensible).
+fn short_cluster_id(id: &str) -> String {
+    let trimmed = id.trim_start_matches("http://").trim_start_matches("https://");
+    let host_port = trimmed.split('/').next().unwrap_or(trimmed);
+    if host_port.len() > 24 {
+        host_port[..24].to_string()
+    } else {
+        host_port.to_string()
+    }
+}
+
+fn format_command(cmd: &OrchestratorCommand) -> String {
+    match cmd {
+        OrchestratorCommand::SetPlayers(c) => format!("set_players({})", c.player_count),
+        OrchestratorCommand::SetSpawnDelayMs(c) => format!("set_spawn_delay_ms({})", c.spawn_delay_ms),
+        OrchestratorCommand::Stop => "stop".to_string(),
+    }
+}

--- a/crates/benchmark-controller/src/lib.rs
+++ b/crates/benchmark-controller/src/lib.rs
@@ -6,6 +6,7 @@
 //! Test scaffolds for each component land here; implementations land in
 //! follow-up PRs.
 
+pub mod dashboard;
 pub mod gate;
 pub mod orchestrator_client;
 pub mod plan;

--- a/crates/benchmark-controller/src/run.rs
+++ b/crates/benchmark-controller/src/run.rs
@@ -6,6 +6,7 @@
 //!
 //! This is what the `benchmark-controller` binary calls from `main`.
 
+use crate::dashboard::{spawn_dashboard, DashboardState};
 use crate::gate::Evaluation;
 use crate::orchestrator_client::HttpOrchestratorClient;
 use crate::plan::{parse, TestPlan};
@@ -13,12 +14,14 @@ use crate::results::{
     OverallOutcome, PhaseOutcome, PhaseOutcomeEntry, PhaseResult, ResultsWriter, RunManifest,
     Uploader,
 };
-use crate::scheduler::{RampScheduler, SchedulerOutcome};
+use crate::scheduler::{OrchestratorClient, RampScheduler, SchedulerOutcome};
 use crate::sse_consumer::{spawn_sse_consumer, LiveGateSignal, LiveGateState};
+use arcane_swarm_orchestrator::telemetry::TelemetrySnapshot;
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
+use tokio::sync::{broadcast, RwLock};
 
 /// Configuration for one controller run.
 pub struct RunConfig {
@@ -30,6 +33,11 @@ pub struct RunConfig {
     pub results_dir: PathBuf,
     /// Submitter id recorded with each command in the orchestrator log.
     pub submitter: String,
+    /// Whether to render the live ASCII dashboard to stdout. Callers
+    /// should set this to `std::io::stdout().is_terminal()` (auto) or
+    /// override via a CLI flag. When false, only the binary's terminal
+    /// summary line is printed.
+    pub enable_dashboard: bool,
 }
 
 /// Final outcome of a run.
@@ -80,13 +88,43 @@ where
             .and_then(|p| p.gate.clone())
             .unwrap_or_default(),
     ));
-    let _sse = spawn_sse_consumer(cfg.orchestrator_base_url.clone(), live_gate.clone());
+
+    // Snapshot broadcast — single SSE connection feeds both the gate
+    // ingestion path and the dashboard. Capacity 64 covers ~2 min of 2-Hz
+    // snapshots before a slow subscriber would Lag (which the dashboard
+    // tolerates by skipping).
+    let (snap_tx, snap_rx_for_dashboard) = broadcast::channel::<TelemetrySnapshot>(64);
+    let _sse = spawn_sse_consumer(
+        cfg.orchestrator_base_url.clone(),
+        live_gate.clone(),
+        Some(snap_tx.clone()),
+    );
+
+    // Dashboard wiring. The `DashboardState` is updated by the per-phase
+    // loop below as phases progress and gate state changes, so the
+    // renderer can show the current phase, hold progress, and gate.
+    let dashboard_state = Arc::new(RwLock::new(DashboardState::new(plan.clone())));
+    let _dashboard = if cfg.enable_dashboard {
+        Some(spawn_dashboard(dashboard_state.clone(), snap_rx_for_dashboard))
+    } else {
+        // Drop the receiver so the broadcast doesn't keep buffering
+        // when no one will read.
+        drop(snap_rx_for_dashboard);
+        None
+    };
 
     let abort_flag = Arc::new(AtomicBool::new(false));
     install_sigint_handler(abort_flag.clone());
 
     let started_at_unix_ms = now_unix_ms();
     let started_at = Instant::now();
+    {
+        // Anchor the dashboard's "elapsed" clock to the same start instant
+        // so the on-screen counter matches the manifest's started_at.
+        let mut s = dashboard_state.write().await;
+        s.overall_started_at = started_at;
+        s.phase_started_at = started_at;
+    }
 
     let mut phase_outcomes: Vec<PhaseOutcomeEntry> = Vec::new();
     let mut overall = OverallOutcome::Pass;
@@ -103,6 +141,12 @@ where
 
         let phase_started = now_unix_ms();
         let phase_started_inst = Instant::now();
+        {
+            let mut s = dashboard_state.write().await;
+            s.current_phase_index = idx;
+            s.phase_started_at = phase_started_inst;
+            s.gate_state = "pass".to_string();
+        }
         let single_phase_plan = TestPlan {
             plan: plan.plan.clone(),
             phases: vec![phase.clone()],
@@ -110,7 +154,8 @@ where
         let client =
             HttpOrchestratorClient::new(cfg.orchestrator_base_url.clone(), cfg.submitter.clone());
         let signal = LiveGateSignal::new(live_gate.clone());
-        let mut scheduler = RampScheduler::new(single_phase_plan, client, signal);
+        let mut scheduler = RampScheduler::new(single_phase_plan, client, signal)
+            .with_emit_terminal_stop_on_completed(false);
         // Share the abort flag across all per-phase schedulers.
         scheduler.abort = abort_flag.clone();
         let outcome = scheduler.run().await;
@@ -130,6 +175,15 @@ where
                 reason: "manual abort".into(),
             },
         };
+        {
+            let mut s = dashboard_state.write().await;
+            s.gate_state = match &phase_outcome {
+                PhaseOutcome::Pass => "pass",
+                PhaseOutcome::Fail { .. } => "fail",
+                PhaseOutcome::Skipped { .. } => "skipped",
+            }
+            .to_string();
+        }
         let _ = phase_dur; // available for future driver-metrics aggregation
 
         let _ = writer
@@ -168,6 +222,28 @@ where
             }
             break;
         }
+    }
+
+    // Terminal Stop — submitted exactly once after all phases finish (or
+    // we broke out early on failure). The per-phase schedulers no longer
+    // emit Stop on Completed (they did, which tore drivers down between
+    // phases). On manual abort / gate failure, the per-phase scheduler
+    // already emitted Stop, so this is a redundant best-effort.
+    {
+        use arcane_swarm_orchestrator::protocol::OrchestratorCommand;
+        let client =
+            HttpOrchestratorClient::new(cfg.orchestrator_base_url.clone(), cfg.submitter.clone());
+        let _ = client.submit(OrchestratorCommand::Stop).await;
+    }
+
+    // Signal the dashboard task to clear its screen and exit so the
+    // binary's terminal summary line below isn't overwritten.
+    {
+        let mut s = dashboard_state.write().await;
+        s.finished = true;
+    }
+    if let Some(h) = _dashboard {
+        let _ = tokio::time::timeout(std::time::Duration::from_secs(3), h).await;
     }
 
     let ended_at_unix_ms = now_unix_ms();

--- a/crates/benchmark-controller/src/scheduler.rs
+++ b/crates/benchmark-controller/src/scheduler.rs
@@ -59,6 +59,14 @@ pub struct RampScheduler<C: OrchestratorClient + 'static, G: GateSignal + 'stati
     /// this to true to short-circuit the run; the scheduler emits Stop and
     /// returns `SchedulerOutcome::Manual`.
     pub abort: Arc<AtomicBool>,
+    /// Whether to emit `Stop` after a successful Completed run. Defaults to
+    /// true (back-compat for direct callers). The phase-by-phase runner in
+    /// `run.rs` sets this to false because it wraps each phase in its own
+    /// scheduler instance — the inter-phase Stop would tear down all
+    /// drivers between phases and the next phase's commands would race
+    /// against an empty fleet. Manual abort and gate failures still emit
+    /// Stop unconditionally.
+    pub emit_terminal_stop_on_completed: bool,
 }
 
 impl<C: OrchestratorClient + 'static, G: GateSignal + 'static> RampScheduler<C, G> {
@@ -69,11 +77,17 @@ impl<C: OrchestratorClient + 'static, G: GateSignal + 'static> RampScheduler<C, 
             gate,
             gate_poll_interval: Duration::from_secs(2),
             abort: Arc::new(AtomicBool::new(false)),
+            emit_terminal_stop_on_completed: true,
         }
     }
 
     pub fn with_gate_poll_interval(mut self, d: Duration) -> Self {
         self.gate_poll_interval = d;
+        self
+    }
+
+    pub fn with_emit_terminal_stop_on_completed(mut self, v: bool) -> Self {
+        self.emit_terminal_stop_on_completed = v;
         self
     }
 
@@ -151,7 +165,9 @@ impl<C: OrchestratorClient + 'static, G: GateSignal + 'static> RampScheduler<C, 
             }
         }
 
-        let _ = self.client.submit(OrchestratorCommand::Stop).await;
+        if self.emit_terminal_stop_on_completed {
+            let _ = self.client.submit(OrchestratorCommand::Stop).await;
+        }
         SchedulerOutcome::Completed
     }
 }

--- a/crates/benchmark-controller/src/sse_consumer.rs
+++ b/crates/benchmark-controller/src/sse_consumer.rs
@@ -13,7 +13,7 @@ use crate::scheduler::{GateSignal, GateState};
 use arcane_swarm_orchestrator::telemetry::TelemetrySnapshot;
 use futures::StreamExt;
 use std::sync::Arc;
-use tokio::sync::{Mutex, RwLock};
+use tokio::sync::{broadcast, Mutex, RwLock};
 
 /// Live, mutable phase state that both the scheduler and the SSE consumer
 /// read/write.
@@ -71,18 +71,26 @@ impl GateSignal for LiveGateSignal {
 
 /// Spawn an SSE consumer task. The task holds an HTTP/SSE connection to
 /// `<base_url>/telemetry/stream`, parses each event into a
-/// `TelemetrySnapshot`, and feeds it into `state`. Returns a JoinHandle the
-/// caller can abort on shutdown.
+/// `TelemetrySnapshot`, feeds it into `state` for gate evaluation, and (if
+/// `snap_tx` is `Some`) re-broadcasts the parsed snapshot so other consumers
+/// (notably the dashboard) can subscribe without opening a second SSE
+/// connection. Returns a JoinHandle the caller can abort on shutdown.
 pub fn spawn_sse_consumer(
     base_url: String,
     state: Arc<LiveGateState>,
+    snap_tx: Option<broadcast::Sender<TelemetrySnapshot>>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         let url = format!("{}/telemetry/stream", base_url.trim_end_matches('/'));
-        let client = reqwest::Client::builder()
-            .timeout(std::time::Duration::from_secs(0))
-            .build();
-        let client = match client {
+        // No client-level timeout — SSE responses are open-ended streams,
+        // and reqwest's default timeout is "none" if we simply don't call
+        // .timeout(). Previous code called .timeout(Duration::from_secs(0))
+        // which is a *literal* 0-second timeout, not a sentinel — every
+        // request fired and immediately timed out, so the consumer
+        // silently never ingested a snapshot in production. The live gate
+        // then sat at its default `Pass` evaluation indefinitely, which
+        // looked like working metrics but was actually an empty signal.
+        let client = match reqwest::Client::builder().build() {
             Ok(c) => c,
             Err(_) => return,
         };
@@ -114,6 +122,9 @@ pub fn spawn_sse_consumer(
                         if let Some(json_str) = line.strip_prefix("data: ") {
                             if let Ok(snap) = serde_json::from_str::<TelemetrySnapshot>(json_str) {
                                 state.ingest(&snap).await;
+                                if let Some(tx) = &snap_tx {
+                                    let _ = tx.send(snap);
+                                }
                             }
                         }
                     }

--- a/crates/benchmark-controller/tests/full_loop_e2e.rs
+++ b/crates/benchmark-controller/tests/full_loop_e2e.rs
@@ -202,6 +202,7 @@ async fn full_loop_writes_phase_files_and_manifest() {
         orchestrator_base_url: http_url.clone(),
         results_dir: results_dir.clone(),
         submitter: "smoke-test".to_string(),
+        enable_dashboard: false,
     };
     let outcome = run(cfg, Arc::new(NoopUploaderExt))
         .await

--- a/infra/aws/Run-Benchmark-Aws-Controller.ps1
+++ b/infra/aws/Run-Benchmark-Aws-Controller.ps1
@@ -146,6 +146,9 @@ function Wait-Ssm {
     while ((Get-Date) -lt $deadline) {
         $r = aws ssm get-command-invocation --region $region --command-id $CommandId --instance-id $InstanceId --output json 2>$null | ConvertFrom-Json
         if ($r -and $r.Status -in @('Success','Failed','Cancelled','TimedOut')) {
+            if ($r.Status -ne 'Success') {
+                throw "SSM command $CommandId on $InstanceId ended with Status=$($r.Status). stderr: $($r.StandardErrorContent)"
+            }
             return $r
         }
         Start-Sleep -Seconds 3
@@ -153,38 +156,59 @@ function Wait-Ssm {
     throw "SSM command $CommandId on $InstanceId timed out after ${TimeoutSec}s"
 }
 
-# ── 1. Pull image on every node + start support containers ───────────────────
-$startSupport = @"
-set -euo pipefail
-docker pull $BenchmarkImage
-"@
+# ── 0. Wait for cloud-init (Docker install) on every node ────────────────────
+# Fresh `terraform apply` returns when EC2 instances are running, but the
+# user-data script (Docker install + AWS CLI install) may still be in
+# progress. Hammering SSM with `docker pull` before that finishes hits
+# "docker: not found" and the run dies. Block until every node responds
+# OK to `which docker`.
+$allInstances = @($managerInstanceId) + $clusterInstanceIds + $driverInstanceIds + @($spacetimeInstanceId, $redisInstanceId) | Where-Object { $_ }
+Write-Host "==> waiting for cloud-init (docker install) on $($allInstances.Count) nodes"
+foreach ($id in $allInstances) {
+    $deadline = (Get-Date).AddMinutes(8)
+    $ready = $false
+    while ((Get-Date) -lt $deadline) {
+        $cmdId = aws ssm send-command --region $region --instance-ids $id --document-name "AWS-RunShellScript" --parameters 'commands=["which docker"]' --output text --query 'Command.CommandId' 2>$null
+        if (-not $cmdId) {
+            # SSM agent itself not online yet
+            Start-Sleep -Seconds 8
+            continue
+        }
+        Start-Sleep -Seconds 4
+        $status = aws ssm get-command-invocation --region $region --command-id $cmdId --instance-id $id --output text --query 'Status' 2>$null
+        if ($status -eq 'Success') { $ready = $true; break }
+        Start-Sleep -Seconds 6
+    }
+    if (-not $ready) {
+        throw "cloud-init did not install docker on $id within 8 minutes"
+    }
+    Write-Host "   docker ready on $id"
+}
 
+# ── 1. Pull image on every node + start support containers ───────────────────
 Write-Host "==> pulling image on all nodes"
 $pullCmds = @{}
-foreach ($id in @($managerInstanceId) + $clusterInstanceIds + $driverInstanceIds + @($spacetimeInstanceId, $redisInstanceId)) {
-    if (-not $id) { continue }
-    $pullCmds[$id] = Invoke-Ssm -InstanceId $id -Commands @($startSupport) -Comment "docker pull $BenchmarkImage"
+foreach ($id in $allInstances) {
+    $pullCmds[$id] = Invoke-Ssm -InstanceId $id -Commands @("docker pull $BenchmarkImage") -Comment "docker pull"
 }
-foreach ($id in $pullCmds.Keys) { Wait-Ssm -CommandId $pullCmds[$id] -InstanceId $id -TimeoutSec 600 | Out-Null }
+foreach ($id in $pullCmds.Keys) { Wait-Ssm -CommandId $pullCmds[$id] -InstanceId $id -TimeoutSec 900 | Out-Null }
 
 # ── 2. Start Redis + SpacetimeDB + publish module ────────────────────────────
 Write-Host "==> starting Redis"
-$redisStart = @"
-set -euo pipefail
-docker rm -f bench-redis 2>/dev/null || true
-docker run -d --name bench-redis --restart unless-stopped --network host redis:7-alpine redis-server --appendonly yes
-"@
-Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $redisInstanceId -Commands @($redisStart) -Comment "redis") -InstanceId $redisInstanceId | Out-Null
+$redisCmds = @(
+    "docker rm -f bench-redis 2>/dev/null || true",
+    "docker run -d --name bench-redis --restart unless-stopped --network host redis:7-alpine redis-server --appendonly yes"
+)
+Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $redisInstanceId -Commands $redisCmds -Comment "redis") -InstanceId $redisInstanceId | Out-Null
 
 Write-Host "==> starting SpacetimeDB + publishing module"
-$stStart = @"
-set -euo pipefail
-docker rm -f bench-spacetime 2>/dev/null || true
-docker run -d --name bench-spacetime --restart unless-stopped --network host $BenchmarkImage spacetime start
-for i in {1..60}; do bash -c 'echo > /dev/tcp/127.0.0.1/3000' 2>/dev/null && break; sleep 2; done
-docker run --rm --network host $BenchmarkImage benchmark-publish-module --mode Persist --host http://127.0.0.1:3000
-"@
-Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $spacetimeInstanceId -Commands @($stStart) -Comment "spacetime+publish") -InstanceId $spacetimeInstanceId -TimeoutSec 600 | Out-Null
+$stCmds = @(
+    "docker rm -f bench-spacetime 2>/dev/null || true",
+    "docker run -d --name bench-spacetime --restart unless-stopped --network host $BenchmarkImage spacetime start",
+    "for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do bash -c 'echo > /dev/tcp/127.0.0.1/3000' 2>/dev/null && break; sleep 2; done",
+    "docker run --rm --network host $BenchmarkImage benchmark-publish-module --mode Persist --host http://127.0.0.1:3000"
+)
+Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $spacetimeInstanceId -Commands $stCmds -Comment "spacetime+publish") -InstanceId $spacetimeInstanceId -TimeoutSec 600 | Out-Null
 
 # ── 3. Start cluster fleet ───────────────────────────────────────────────────
 $redisHost     = (aws ec2 describe-instances --region $region --instance-ids $redisInstanceId --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text 2>$null)
@@ -195,20 +219,8 @@ for ($i = 0; $i -lt $clusterInstanceIds.Count; $i++) {
     $cid     = $clusterInstanceIds[$i]
     $cuid    = $clusterIds[$i]
     $clusPort = 8090
-    $clStart = @"
-set -euo pipefail
-docker rm -f bench-cluster 2>/dev/null || true
-docker run -d --name bench-cluster --restart unless-stopped --network host \
-  -e CLUSTER_ID=$cuid \
-  -e REDIS_URL=redis://${redisHost}:6379 \
-  -e CLUSTER_WS_PORT=$clusPort \
-  -e SPACETIMEDB_URI=http://${spacetimeHost}:3000 \
-  -e SPACETIMEDB_DATABASE=arcane \
-  -e SPACETIMEDB_PERSIST=1 \
-  -e SPACETIMEDB_PERSIST_HZ=1 \
-  $BenchmarkImage benchmark-cluster
-"@
-    $cmdId = Invoke-Ssm -InstanceId $cid -Commands @($clStart) -Comment "cluster $i"
+    $clRun = "docker run -d --name bench-cluster --restart unless-stopped --network host -e CLUSTER_ID=$cuid -e REDIS_URL=redis://${redisHost}:6379 -e CLUSTER_WS_PORT=$clusPort -e SPACETIMEDB_URI=http://${spacetimeHost}:3000 -e SPACETIMEDB_DATABASE=arcane -e SPACETIMEDB_PERSIST=1 -e SPACETIMEDB_PERSIST_HZ=1 $BenchmarkImage benchmark-cluster"
+    $cmdId = Invoke-Ssm -InstanceId $cid -Commands @("docker rm -f bench-cluster 2>/dev/null || true", $clRun) -Comment "cluster $i"
     Wait-Ssm -CommandId $cmdId -InstanceId $cid | Out-Null
 }
 
@@ -225,59 +237,51 @@ $managerClustersStr = ($managerClusters -join ',')
 $statsUrls = @($clusterPrivateIps | ForEach-Object { "http://${_}:8091/stats" })
 $statsArgs = ($statsUrls | ForEach-Object { "--cluster-stats-url $_" }) -join ' '
 
-$mgrStart = @"
-set -euo pipefail
-docker rm -f bench-manager bench-orchestrator 2>/dev/null || true
-
-docker run -d --name bench-manager --restart unless-stopped --network host \
-  -e MANAGER_HTTP_PORT=8081 \
-  -e MANAGER_CLUSTERS='$managerClustersStr' \
-  $BenchmarkImage arcane-manager
-
-mkdir -p /var/orchestrator
-docker run -d --name bench-orchestrator --restart unless-stopped --network host \
-  -v /var/orchestrator:/var/orchestrator \
-  $BenchmarkImage arcane-swarm-orchestrator \
-    --driver-port $orchDriverPort \
-    --http-port $orchHttpPort \
-    --archive-dir /var/orchestrator/snapshots \
-    --max-drivers 32 \
-    $statsArgs
-"@
-Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $managerInstanceId -Commands @($mgrStart) -Comment "manager+orchestrator") -InstanceId $managerInstanceId | Out-Null
+$mgrCleanup = "docker rm -f bench-manager bench-orchestrator 2>/dev/null || true"
+$mgrRun     = "docker run -d --name bench-manager --restart unless-stopped --network host -e MANAGER_HTTP_PORT=8081 -e MANAGER_CLUSTERS='$managerClustersStr' $BenchmarkImage arcane-manager"
+$mgrMkdir   = "mkdir -p /var/orchestrator"
+$orchRun    = "docker run -d --name bench-orchestrator --restart unless-stopped --network host -v /var/orchestrator:/var/orchestrator $BenchmarkImage arcane-swarm-orchestrator --driver-port $orchDriverPort --http-port $orchHttpPort --archive-dir /var/orchestrator/snapshots --max-drivers 64 $statsArgs"
+Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $managerInstanceId -Commands @($mgrCleanup, $mgrRun, $mgrMkdir, $orchRun) -Comment "manager+orchestrator") -InstanceId $managerInstanceId | Out-Null
 
 # ── 5. Start drivers in orchestrated mode ────────────────────────────────────
 Write-Host "==> starting $($driverInstanceIds.Count) drivers in orchestrated mode"
 $orchUrlInternal = "ws://${managerPrivateIp}:${orchDriverPort}"
+$drvRun = "docker run -d --name bench-driver --restart unless-stopped --network host -e ORCHESTRATOR_URL=$orchUrlInternal $BenchmarkImage arcane-swarm --backend arcane --arcane-manager http://${managerPrivateIp}:8081 --orchestrator-url $orchUrlInternal --tick-rate 60 --max-players 4000 --user-data-bytes 1000 --inter-spawn-delay-ms 8 --max-players-per-driver 4000 --burst-enabled --burst-period-secs 30 --burst-cohort-percent 20 --burst-actions-per-player 10 --burst-window-ms 500 --zone-event-period-secs 30 --zone-event-window-ms 500 --actions-per-sec 2 --read-rate 5 --run-forever"
 foreach ($did in $driverInstanceIds) {
-    $drvStart = @"
-set -euo pipefail
-docker rm -f bench-driver 2>/dev/null || true
-docker run -d --name bench-driver --restart unless-stopped --network host \
-  -e ORCHESTRATOR_URL=$orchUrlInternal \
-  $BenchmarkImage arcane-swarm \
-    --backend arcane \
-    --arcane-manager http://${managerPrivateIp}:8081 \
-    --orchestrator-url $orchUrlInternal \
-    --tick-rate 60 \
-    --max-players 4000 \
-    --user-data-bytes 1000 \
-    --inter-spawn-delay-ms 8 \
-    --max-players-per-driver 4000 \
-    --burst-enabled --burst-period-secs 30 --burst-cohort-percent 20 \
-    --burst-actions-per-player 10 --burst-window-ms 500 \
-    --zone-event-period-secs 30 --zone-event-window-ms 500 \
-    --actions-per-sec 2 --read-rate 5 \
-    --run-forever
-"@
-    Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $did -Commands @($drvStart) -Comment "driver") -InstanceId $did | Out-Null
+    Wait-Ssm -CommandId (Invoke-Ssm -InstanceId $did -Commands @("docker rm -f bench-driver 2>/dev/null || true", $drvRun) -Comment "driver") -InstanceId $did | Out-Null
 }
 
-# Give drivers a moment to register with the orchestrator.
-Start-Sleep -Seconds 8
+# Wait for the orchestrator HTTP API to be reachable and for every driver
+# to register before we hand off to the controller. Uses curl with
+# --max-time so the SSE response (open-ended) doesn't hang the check.
+Write-Host "==> waiting for orchestrator + $($driverInstanceIds.Count) drivers to register"
+$orchUrlPublic = "http://${managerPublicDns}:${orchHttpPort}"
+$expectedDrivers = $driverInstanceIds.Count
+$readyDeadline = (Get-Date).AddSeconds(120)
+$ready = $false
+while ((Get-Date) -lt $readyDeadline) {
+    # `--max-time 3` cuts the SSE stream at 3s. We grab the first `data:`
+    # line, parse it, check fleet size.
+    $raw = & curl -sN --max-time 3 "${orchUrlPublic}/telemetry/stream" 2>$null
+    if ($raw) {
+        $firstData = ($raw -split "`n" | Where-Object { $_ -match '^data: ' } | Select-Object -First 1)
+        if ($firstData) {
+            $json = $firstData -replace '^data:\s*', ''
+            try {
+                $snap = $json | ConvertFrom-Json -ErrorAction Stop
+                $active = ($snap.fleet | Where-Object { $_.state -eq 'Active' }).Count
+                Write-Host "   ($active/$expectedDrivers active)"
+                if ($active -ge $expectedDrivers) { $ready = $true; break }
+            } catch { }
+        }
+    }
+    Start-Sleep -Seconds 2
+}
+if (-not $ready) {
+    Write-Host "WARNING: timed out waiting for full driver registration after 120s; continuing anyway" -ForegroundColor Yellow
+}
 
 # ── 6. Run the controller from the operator's laptop ─────────────────────────
-$orchUrlPublic = "http://${managerPublicDns}:${orchHttpPort}"
 Write-Host "==> running controller against $orchUrlPublic"
 
 $ctlArgs = @(
@@ -294,10 +298,40 @@ if ($S3UploadResults) {
 & $ControllerBinary @ctlArgs
 $ctlExit = $LASTEXITCODE
 
-# ── 7. Stop driver + orchestrator + cluster + support containers ─────────────
+# ── 7. Capture container logs BEFORE teardown ────────────────────────────────
+Write-Host "==> capturing container logs"
+$logsDir = Join-Path $ResultsDir "container-logs"
+New-Item -ItemType Directory -Path $logsDir -Force | Out-Null
+foreach ($id in @($managerInstanceId)) {
+    $cmdId = Invoke-Ssm -InstanceId $id -Commands @("docker logs bench-orchestrator 2>&1 | tail -200", "echo ---SEPARATOR---", "docker logs bench-manager 2>&1 | tail -100") -Comment "logs manager"
+    $r = Wait-Ssm -CommandId $cmdId -InstanceId $id -TimeoutSec 60
+    Set-Content -Path (Join-Path $logsDir "manager-$id.log") -Value ($r.StandardOutputContent + "`n---STDERR---`n" + $r.StandardErrorContent)
+}
+for ($i = 0; $i -lt $driverInstanceIds.Count; $i++) {
+    $id = $driverInstanceIds[$i]
+    try {
+        $cmdId = Invoke-Ssm -InstanceId $id -Commands @("docker logs bench-driver 2>&1 | tail -100") -Comment "logs driver"
+        $r = Wait-Ssm -CommandId $cmdId -InstanceId $id -TimeoutSec 60
+        Set-Content -Path (Join-Path $logsDir "driver-$i-$id.log") -Value ($r.StandardOutputContent + "`n---STDERR---`n" + $r.StandardErrorContent)
+    } catch {
+        Write-Host "   log fetch failed for driver $id" -ForegroundColor Yellow
+    }
+}
+foreach ($i in 0..($clusterInstanceIds.Count - 1)) {
+    $id = $clusterInstanceIds[$i]
+    try {
+        $cmdId = Invoke-Ssm -InstanceId $id -Commands @("docker logs bench-cluster 2>&1 | tail -50") -Comment "logs cluster"
+        $r = Wait-Ssm -CommandId $cmdId -InstanceId $id -TimeoutSec 60
+        Set-Content -Path (Join-Path $logsDir "cluster-$i-$id.log") -Value ($r.StandardOutputContent + "`n---STDERR---`n" + $r.StandardErrorContent)
+    } catch {
+        Write-Host "   log fetch failed for cluster $id" -ForegroundColor Yellow
+    }
+}
+Write-Host "   logs saved under $logsDir"
+
+# ── 8. Stop driver + orchestrator + cluster + support containers ─────────────
 Write-Host "==> stopping all containers"
 $stopAll = "docker rm -f bench-driver bench-orchestrator bench-manager bench-cluster bench-spacetime bench-redis 2>/dev/null || true"
-$allInstances = @($managerInstanceId) + $clusterInstanceIds + $driverInstanceIds + @($spacetimeInstanceId, $redisInstanceId) | Where-Object { $_ }
 foreach ($id in $allInstances) {
     $null = Invoke-Ssm -InstanceId $id -Commands @($stopAll) -Comment "stop"
 }

--- a/infra/aws/cleanup.sh
+++ b/infra/aws/cleanup.sh
@@ -1,0 +1,182 @@
+#!/usr/bin/env bash
+# cleanup.sh — guaranteed-clean teardown of the AWS benchmark fleet.
+#
+# Wraps `terraform destroy` and follows it with an AWS-side audit so the
+# success contract is concrete: either this script exits 0 AND no
+# Project=arcane-benchmark resources remain in the account, or it exits
+# non-zero and prints exactly what's still there.
+#
+# Why a wrapper instead of just running `terraform destroy`:
+# - Idempotent + retryable on AWS API throttling / state-lock contention.
+#   Re-running this script is always safe.
+# - AWS-side audit catches the rare case where terraform reports success
+#   but resources persist (out-of-band references, stale state).
+# - One-line teardown command for the README; users don't have to
+#   remember the right -var-file flags or which directory to cd into.
+#
+# Usage (from the repo root or anywhere — script self-locates):
+#   ./infra/aws/cleanup.sh [--tfvars <name>] [--region <aws-region>]
+#
+# Defaults:
+#   tfvars: arcaneperhost.clusters_4.drivers_12.tfvars (matches the
+#           README's headline reproduction; override if you provisioned
+#           a different topology)
+#   region: us-east-1 (matches the headline tfvars)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TF_DIR="$REPO_ROOT/infra/terraform/aws_benchmark"
+TFVARS="arcaneperhost.clusters_4.drivers_12.tfvars"
+REGION="us-east-1"
+PROJECT_TAG="arcane-benchmark"
+MAX_DESTROY_RETRIES=2
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tfvars) TFVARS="$2"; shift 2 ;;
+        --region) REGION="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,25p' "$0" | sed 's/^# //;s/^#//'
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+TF_BIN="${TERRAFORM:-terraform}"
+if ! command -v "$TF_BIN" >/dev/null 2>&1; then
+    # Fall back to common per-user install paths so users who installed
+    # via tfenv / their own ~/bin still hit the script's happy path
+    # without needing to put terraform on PATH for this shell.
+    for cand in "$HOME/bin/terraform" "$HOME/.local/bin/terraform" "$HOME/.tfenv/bin/terraform"; do
+        if [[ -x "$cand" ]]; then TF_BIN="$cand"; break; fi
+    done
+fi
+command -v "$TF_BIN" >/dev/null 2>&1 || {
+    echo "cleanup.sh: terraform not found on PATH or in common install dirs." >&2
+    echo "  Install: https://developer.hashicorp.com/terraform/install" >&2
+    exit 2
+}
+
+if ! command -v aws >/dev/null 2>&1; then
+    echo "cleanup.sh: aws CLI not found on PATH. Install + configure credentials." >&2
+    exit 2
+fi
+
+if [[ ! -f "$TF_DIR/$TFVARS" ]]; then
+    echo "cleanup.sh: tfvars file not found: $TF_DIR/$TFVARS" >&2
+    echo "  Available tfvars in this module:" >&2
+    ls "$TF_DIR"/*.tfvars 2>&1 | sed 's/^/    /' >&2
+    exit 2
+fi
+
+echo "==> cleanup.sh"
+echo "    terraform module: $TF_DIR"
+echo "    tfvars:           $TFVARS"
+echo "    region:           $REGION"
+echo "    project tag:      Project=$PROJECT_TAG"
+
+# ── 1. terraform destroy with bounded retry ─────────────────────────────────
+attempt=1
+while (( attempt <= MAX_DESTROY_RETRIES + 1 )); do
+    echo "==> terraform destroy (attempt $attempt/$((MAX_DESTROY_RETRIES + 1)))"
+    if "$TF_BIN" -chdir="$TF_DIR" destroy \
+        -var-file="$TFVARS" \
+        -var='operator_cidr_blocks=["0.0.0.0/0"]' \
+        -auto-approve; then
+        echo "    terraform destroy succeeded"
+        break
+    fi
+    if (( attempt > MAX_DESTROY_RETRIES )); then
+        echo "cleanup.sh: terraform destroy failed after $attempt attempts" >&2
+        echo "  Manual recovery options:" >&2
+        echo "    - State lock stuck:    terraform -chdir=$TF_DIR force-unlock <ID>" >&2
+        echo "    - Out-of-band depend:  check AWS console for resources sharing the VPC/SG" >&2
+        echo "  Then re-run this script." >&2
+        exit 1
+    fi
+    echo "    retry in 10s (transient AWS API or state-lock issue)…"
+    sleep 10
+    attempt=$((attempt + 1))
+done
+
+# ── 2. AWS-side audit ───────────────────────────────────────────────────────
+# Terraform thinks it's done. Now verify with the AWS API directly that
+# no Project=arcane-benchmark resources remain. This catches:
+#   - Out-of-band attachments (e.g., a Lambda ENI holding the SG open)
+#   - Stale terraform state (rare but real after force-unlock recovery)
+#   - Cross-region drift (we only audit $REGION but at least confirm here)
+echo "==> AWS-side audit (Project=$PROJECT_TAG, region=$REGION)"
+LEAK_COUNT=0
+
+# EC2 instances (any non-terminated state)
+ec2_leftovers=$(aws ec2 describe-instances \
+    --region "$REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_TAG" \
+              "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" \
+    --query 'Reservations[].Instances[].[InstanceId,State.Name,Tags[?Key==`Name`]|[0].Value]' \
+    --output text 2>/dev/null || true)
+if [[ -n "$ec2_leftovers" ]]; then
+    LEAK_COUNT=$((LEAK_COUNT + $(echo "$ec2_leftovers" | wc -l)))
+    echo "    EC2 leftovers:"
+    echo "$ec2_leftovers" | sed 's/^/      /'
+fi
+
+# Security groups
+sg_leftovers=$(aws ec2 describe-security-groups \
+    --region "$REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_TAG" \
+    --query 'SecurityGroups[].[GroupId,GroupName]' \
+    --output text 2>/dev/null || true)
+if [[ -n "$sg_leftovers" ]]; then
+    LEAK_COUNT=$((LEAK_COUNT + $(echo "$sg_leftovers" | wc -l)))
+    echo "    Security group leftovers:"
+    echo "$sg_leftovers" | sed 's/^/      /'
+fi
+
+# VPCs (only those we created — default VPC has no Project tag so it's safe)
+vpc_leftovers=$(aws ec2 describe-vpcs \
+    --region "$REGION" \
+    --filters "Name=tag:Project,Values=$PROJECT_TAG" \
+    --query 'Vpcs[].[VpcId,CidrBlock]' \
+    --output text 2>/dev/null || true)
+if [[ -n "$vpc_leftovers" ]]; then
+    LEAK_COUNT=$((LEAK_COUNT + $(echo "$vpc_leftovers" | wc -l)))
+    echo "    VPC leftovers:"
+    echo "$vpc_leftovers" | sed 's/^/      /'
+fi
+
+# IAM roles / instance profiles. These don't carry the Project tag in the
+# current module, so we filter by name prefix matching what the module
+# creates. Stay narrow on the prefix to avoid eating user-created IAM.
+iam_leftovers=$(aws iam list-roles \
+    --query 'Roles[?starts_with(RoleName, `ArcaneBenchmark`)].[RoleName]' \
+    --output text 2>/dev/null || true)
+if [[ -n "$iam_leftovers" ]]; then
+    LEAK_COUNT=$((LEAK_COUNT + $(echo "$iam_leftovers" | wc -l)))
+    echo "    IAM role leftovers:"
+    echo "$iam_leftovers" | sed 's/^/      /'
+fi
+
+# S3 buckets — module names them arcane-benchmark-artifacts-<account>-<region>.
+# Filter conservatively to avoid touching user buckets.
+s3_leftovers=$(aws s3api list-buckets \
+    --query 'Buckets[?starts_with(Name, `arcane-benchmark-artifacts-`)].[Name]' \
+    --output text 2>/dev/null || true)
+if [[ -n "$s3_leftovers" ]]; then
+    LEAK_COUNT=$((LEAK_COUNT + $(echo "$s3_leftovers" | wc -l)))
+    echo "    S3 bucket leftovers:"
+    echo "$s3_leftovers" | sed 's/^/      /'
+fi
+
+# ── 3. Final verdict ────────────────────────────────────────────────────────
+if (( LEAK_COUNT == 0 )); then
+    echo "==> CLEAN: terraform destroy succeeded AND no Project=$PROJECT_TAG resources remain in $REGION."
+    exit 0
+else
+    echo "==> LEAK: terraform reported success but $LEAK_COUNT resources still exist (listed above)." >&2
+    echo "    Most common cause: out-of-band references (e.g., a Lambda ENI keeping" >&2
+    echo "    the security group attached). Investigate in the AWS console." >&2
+    exit 1
+fi

--- a/infra/aws/run-benchmark-aws-controller.sh
+++ b/infra/aws/run-benchmark-aws-controller.sh
@@ -1,0 +1,249 @@
+#!/usr/bin/env bash
+# Bash counterpart to Run-Benchmark-Aws-Controller.ps1.
+# Designed to be runnable from any POSIX shell (WSL, Linux, macOS) with the
+# AWS CLI configured, so the operator can iterate without dropping into
+# Windows PowerShell. Same lifecycle as the .ps1: restart containers via SSM,
+# wait for driver registration, run the local benchmark-controller binary
+# against the orchestrator's HTTP API, capture logs, stop containers.
+#
+# Assumes the infra is already provisioned (terraform apply has run and the
+# state json is at the expected path) and the docker daemon is already
+# installed on every node (cloud-init done). Re-running this against a
+# previously-torn-down fleet is the expected case.
+#
+# Usage:
+#   ./run-benchmark-aws-controller.sh \
+#     --state-path .benchmark-aws-terraform.json \
+#     --plan plans/headline-13500.toml \
+#     --image ghcr.io/brainy-bots/arcane-benchmark:dev-... \
+#     --controller-binary /path/to/benchmark-controller
+
+set -euo pipefail
+
+STATE_PATH=""
+PLAN_FILE=""
+BENCHMARK_IMAGE=""
+CONTROLLER_BINARY=""
+RESULTS_DIR=""
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --state-path) STATE_PATH="$2"; shift 2 ;;
+        --plan) PLAN_FILE="$2"; shift 2 ;;
+        --image) BENCHMARK_IMAGE="$2"; shift 2 ;;
+        --controller-binary) CONTROLLER_BINARY="$2"; shift 2 ;;
+        --results-dir) RESULTS_DIR="$2"; shift 2 ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+[[ -z "$STATE_PATH" || ! -f "$STATE_PATH" ]] && { echo "missing --state-path" >&2; exit 2; }
+[[ -z "$PLAN_FILE"  || ! -f "$PLAN_FILE" ]] && { echo "missing --plan" >&2; exit 2; }
+[[ -z "$BENCHMARK_IMAGE" ]] && { echo "missing --image" >&2; exit 2; }
+[[ -z "$CONTROLLER_BINARY" || ! -x "$CONTROLLER_BINARY" ]] && { echo "missing/non-executable --controller-binary" >&2; exit 2; }
+
+REGION=$(jq -r '.Region' "$STATE_PATH")
+ENV_NAME=$(jq -r '.Environment' "$STATE_PATH")
+MANAGER_ID=$(jq -r '.ManagerInstanceId' "$STATE_PATH")
+MANAGER_PRIVATE_IP=$(jq -r '.ManagerPrivateIp' "$STATE_PATH")
+MANAGER_PUBLIC_DNS=$(jq -r '.ManagerPublicDns' "$STATE_PATH")
+ORCH_HTTP_PORT=$(jq -r '.OrchestratorHttpPort // 8090' "$STATE_PATH")
+ORCH_DRIVER_PORT=$(jq -r '.OrchestratorDriverPort // 8088' "$STATE_PATH")
+REDIS_ID=$(jq -r '.RedisInstanceId' "$STATE_PATH")
+SPACETIME_ID=$(jq -r '.SpacetimeInstanceId' "$STATE_PATH")
+mapfile -t CLUSTER_IDS < <(jq -r '.ClusterIds[]' "$STATE_PATH")
+mapfile -t CLUSTER_INST < <(jq -r '.ClusterInstanceIds[]' "$STATE_PATH")
+mapfile -t CLUSTER_IPS  < <(jq -r '.ClusterPrivateIps[]' "$STATE_PATH")
+mapfile -t DRIVER_IDS   < <(jq -r '.BenchmarkInstanceIds[]' "$STATE_PATH")
+
+RUN_ID=$(date +%Y%m%d_%H%M%S)
+[[ -z "$RESULTS_DIR" ]] && RESULTS_DIR="$(dirname "$0")/../../results/runs/${ENV_NAME}/${RUN_ID}"
+mkdir -p "$RESULTS_DIR"
+LOGS_DIR="$RESULTS_DIR/container-logs"
+mkdir -p "$LOGS_DIR"
+
+ORCH_PUBLIC="http://${MANAGER_PUBLIC_DNS}:${ORCH_HTTP_PORT}"
+ORCH_INTERNAL="ws://${MANAGER_PRIVATE_IP}:${ORCH_DRIVER_PORT}"
+
+echo "==> environment:        $ENV_NAME"
+echo "==> manager:            $MANAGER_ID ($MANAGER_PUBLIC_DNS)"
+echo "==> clusters:           ${#CLUSTER_INST[@]}"
+echo "==> drivers:            ${#DRIVER_IDS[@]}"
+echo "==> image:              $BENCHMARK_IMAGE"
+echo "==> orchestrator URL:   $ORCH_PUBLIC"
+echo "==> results dir:        $RESULTS_DIR"
+
+# ─── helpers ─────────────────────────────────────────────────────────────────
+# Submit a single shell command to one EC2 via SSM, block until it terminates,
+# return the exit code. We pass commands as a single shell -c so multi-line
+# scripts and pipes survive. Output is discarded by default; use
+# `ssm_capture` if you need stdout.
+_ssm_send() {
+    # Marshal the script through a temp JSON file so embedded newlines and
+    # quotes survive AWS CLI's parameter parser (the inline `commands=[...]`
+    # form turns "\n" into literal `n` after the backslash gets stripped).
+    local id="$1"; shift
+    local script="$*"
+    local tmp
+    tmp=$(mktemp)
+    jq -n --arg s "$script" '{commands:[$s]}' > "$tmp"
+    aws ssm send-command --region "$REGION" \
+        --instance-ids "$id" \
+        --document-name AWS-RunShellScript \
+        --parameters "file://$tmp" \
+        --output text --query 'Command.CommandId'
+    local rc=$?
+    rm -f "$tmp"
+    return $rc
+}
+
+ssm_run() {
+    local id="$1"; shift
+    local cmd_id
+    cmd_id=$(_ssm_send "$id" "$@") || return 1
+    local status
+    while true; do
+        sleep 3
+        status=$(aws ssm get-command-invocation --region "$REGION" \
+            --command-id "$cmd_id" --instance-id "$id" \
+            --output text --query 'Status' 2>/dev/null || echo "")
+        case "$status" in
+            Success) return 0 ;;
+            Failed|Cancelled|TimedOut)
+                aws ssm get-command-invocation --region "$REGION" \
+                    --command-id "$cmd_id" --instance-id "$id" \
+                    --output json >&2
+                return 1
+                ;;
+        esac
+    done
+}
+
+ssm_capture() {
+    local id="$1"; shift
+    local cmd_id
+    cmd_id=$(_ssm_send "$id" "$@") || return 1
+    while true; do
+        sleep 2
+        local status
+        status=$(aws ssm get-command-invocation --region "$REGION" \
+            --command-id "$cmd_id" --instance-id "$id" \
+            --output text --query 'Status' 2>/dev/null || echo "")
+        if [[ "$status" == "Success" || "$status" == "Failed" || "$status" == "Cancelled" || "$status" == "TimedOut" ]]; then
+            aws ssm get-command-invocation --region "$REGION" \
+                --command-id "$cmd_id" --instance-id "$id" \
+                --output text --query 'StandardOutputContent'
+            return 0
+        fi
+    done
+}
+
+# ─── 1. pull image on every node ─────────────────────────────────────────────
+ALL_IDS=("$MANAGER_ID" "${CLUSTER_INST[@]}" "${DRIVER_IDS[@]}" "$SPACETIME_ID" "$REDIS_ID")
+echo "==> pulling image on ${#ALL_IDS[@]} nodes"
+for id in "${ALL_IDS[@]}"; do
+    ssm_run "$id" "docker pull $BENCHMARK_IMAGE" &
+done
+wait
+echo "   image pulled"
+
+# ─── 2. Redis + SpacetimeDB ──────────────────────────────────────────────────
+echo "==> starting Redis"
+ssm_run "$REDIS_ID" "docker rm -f bench-redis 2>/dev/null || true; docker run -d --name bench-redis --restart unless-stopped --network host redis:7-alpine redis-server --appendonly yes"
+
+echo "==> starting SpacetimeDB + publishing module"
+ssm_run "$SPACETIME_ID" "docker rm -f bench-spacetime 2>/dev/null || true; docker run -d --name bench-spacetime --restart unless-stopped --network host $BENCHMARK_IMAGE spacetime start; for i in \$(seq 1 30); do bash -c 'echo > /dev/tcp/127.0.0.1/3000' 2>/dev/null && break; sleep 2; done; docker run --rm --network host $BENCHMARK_IMAGE benchmark-publish-module --mode Persist --host http://127.0.0.1:3000"
+
+REDIS_HOST=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$REDIS_ID" --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text)
+SPACE_HOST=$(aws ec2 describe-instances --region "$REGION" --instance-ids "$SPACETIME_ID" --query 'Reservations[0].Instances[0].PrivateIpAddress' --output text)
+
+# ─── 3. clusters ─────────────────────────────────────────────────────────────
+echo "==> starting clusters (Redis=$REDIS_HOST, ST=$SPACE_HOST)"
+for i in "${!CLUSTER_INST[@]}"; do
+    cid="${CLUSTER_INST[$i]}"
+    cuid="${CLUSTER_IDS[$i]}"
+    ssm_run "$cid" "docker rm -f bench-cluster 2>/dev/null || true; docker run -d --name bench-cluster --restart unless-stopped --ulimit nofile=65536:65536 --network host -e CLUSTER_ID=$cuid -e REDIS_URL=redis://${REDIS_HOST}:6379 -e CLUSTER_WS_PORT=8090 -e SPACETIMEDB_URI=http://${SPACE_HOST}:3000 -e SPACETIMEDB_DATABASE=arcane -e SPACETIMEDB_PERSIST=1 -e SPACETIMEDB_PERSIST_HZ=1 $BENCHMARK_IMAGE benchmark-cluster" &
+done
+wait
+
+# ─── 4. manager + orchestrator ──────────────────────────────────────────────
+echo "==> starting manager + orchestrator on $MANAGER_ID"
+MGR_CLUSTERS=""
+for i in "${!CLUSTER_IDS[@]}"; do
+    [[ -n "$MGR_CLUSTERS" ]] && MGR_CLUSTERS+=","
+    MGR_CLUSTERS+="${CLUSTER_IDS[$i]}:${CLUSTER_IPS[$i]}:8090"
+done
+STATS_ARGS=""
+for ip in "${CLUSTER_IPS[@]}"; do
+    STATS_ARGS+=" --cluster-stats-url http://${ip}:8091/stats"
+done
+
+ssm_run "$MANAGER_ID" "docker rm -f bench-manager bench-orchestrator 2>/dev/null || true; docker run -d --name bench-manager --restart unless-stopped --ulimit nofile=65536:65536 --network host -e MANAGER_HTTP_PORT=8081 -e MANAGER_CLUSTERS='$MGR_CLUSTERS' $BENCHMARK_IMAGE arcane-manager; mkdir -p /var/orchestrator; docker run -d --name bench-orchestrator --restart unless-stopped --ulimit nofile=65536:65536 --network host -v /var/orchestrator:/var/orchestrator $BENCHMARK_IMAGE arcane-swarm-orchestrator --driver-port $ORCH_DRIVER_PORT --http-port $ORCH_HTTP_PORT --archive-dir /var/orchestrator/snapshots --max-drivers 64 $STATS_ARGS"
+
+# ─── 5. drivers ──────────────────────────────────────────────────────────────
+echo "==> starting ${#DRIVER_IDS[@]} drivers"
+DRV_RUN="docker rm -f bench-driver 2>/dev/null || true; docker run -d --name bench-driver --restart unless-stopped --ulimit nofile=65536:65536 --network host -e ORCHESTRATOR_URL=$ORCH_INTERNAL $BENCHMARK_IMAGE arcane-swarm --backend arcane --arcane-manager http://${MANAGER_PRIVATE_IP}:8081 --orchestrator-url $ORCH_INTERNAL --tick-rate 60 --max-players 4000 --user-data-bytes 1000 --inter-spawn-delay-ms 8 --max-players-per-driver 4000 --burst-enabled --burst-period-secs 30 --burst-cohort-percent 20 --burst-actions-per-player 10 --burst-window-ms 500 --zone-event-period-secs 30 --zone-event-window-ms 500 --actions-per-sec 2 --read-rate 5 --run-forever"
+for did in "${DRIVER_IDS[@]}"; do
+    ssm_run "$did" "$DRV_RUN" &
+done
+wait
+
+# ─── 6. wait for drivers to register ────────────────────────────────────────
+echo "==> waiting for ${#DRIVER_IDS[@]} drivers to register"
+EXPECTED=${#DRIVER_IDS[@]}
+DEADLINE=$(( $(date +%s) + 180 ))
+while (( $(date +%s) < DEADLINE )); do
+    raw=$(curl -sN --max-time 3 "${ORCH_PUBLIC}/telemetry/stream" 2>/dev/null || true)
+    first=$(echo "$raw" | grep -m1 '^data: ' | sed 's/^data: //')
+    if [[ -n "$first" ]]; then
+        active=$(echo "$first" | jq '[.fleet[] | select(.state=="Active")] | length' 2>/dev/null || echo 0)
+        echo "   ($active/$EXPECTED active)"
+        if (( active >= EXPECTED )); then break; fi
+    fi
+    sleep 2
+done
+
+# ─── 7. run controller ───────────────────────────────────────────────────────
+echo "==> running controller"
+set +e
+"$CONTROLLER_BINARY" \
+    --plan "$PLAN_FILE" \
+    --orchestrator-url "$ORCH_PUBLIC" \
+    --results-dir "$RESULTS_DIR" \
+    --submitter "operator-bash" \
+    --dashboard "${DASHBOARD:-auto}"
+CTL_EXIT=$?
+set -e
+
+# ─── 8. capture logs ─────────────────────────────────────────────────────────
+echo "==> capturing logs to $LOGS_DIR"
+{
+    ssm_capture "$MANAGER_ID" "docker logs bench-orchestrator 2>&1 | tail -300; echo '---SEPARATOR---'; docker logs bench-manager 2>&1 | tail -100"
+} > "$LOGS_DIR/manager-${MANAGER_ID}.log"
+
+for i in "${!DRIVER_IDS[@]}"; do
+    did="${DRIVER_IDS[$i]}"
+    ssm_capture "$did" "docker logs bench-driver 2>&1 | tail -200" > "$LOGS_DIR/driver-${i}-${did}.log" &
+done
+wait
+
+for i in "${!CLUSTER_INST[@]}"; do
+    cid="${CLUSTER_INST[$i]}"
+    ssm_capture "$cid" "docker logs bench-cluster 2>&1 | tail -100" > "$LOGS_DIR/cluster-${i}-${cid}.log" &
+done
+wait
+
+# ─── 9. teardown ─────────────────────────────────────────────────────────────
+echo "==> stopping containers"
+STOP_ALL="docker rm -f bench-driver bench-orchestrator bench-manager bench-cluster bench-spacetime bench-redis 2>/dev/null || true"
+for id in "${ALL_IDS[@]}"; do
+    ssm_run "$id" "$STOP_ALL" &
+done
+wait
+
+if [[ $CTL_EXIT -eq 0 ]]; then
+    echo "==> controller exit 0 (overall PASS)"
+else
+    echo "==> controller exit $CTL_EXIT"
+fi
+exit $CTL_EXIT

--- a/infra/aws/setup.sh
+++ b/infra/aws/setup.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# setup.sh — provision the AWS benchmark fleet end-to-end.
+#
+# Wraps `terraform init` + `terraform apply` and replaces the README's
+# fragile manual step ("wait ~60 seconds for SSM agents") with a real
+# poll: doesn't return until every EC2 reports SSM Online. After that,
+# downstream run scripts can hit any node via SSM with no surprises.
+#
+# Why a wrapper instead of just running terraform apply:
+# - One command for the README. No `cd infra/terraform/aws_benchmark`
+#   dance, no remembering -var-file=... flags.
+# - Idempotent + retryable. Re-running this script when infra is already
+#   up is a no-op (terraform refresh + 0 changes + SSM ready).
+# - Writes the canonical state JSON the run scripts expect, in the
+#   canonical location, every time. No off-by-one path bugs.
+# - The SSM-readiness wait closes the most common race users hit when
+#   following the README.
+#
+# Usage (from the repo root or anywhere — script self-locates):
+#   ./infra/aws/setup.sh [--tfvars <name>] [--region <aws-region>]
+#
+# Defaults:
+#   tfvars: arcaneperhost.clusters_4.drivers_12.tfvars (matches the
+#           README's headline reproduction)
+#   region: us-east-1
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+TF_DIR="$REPO_ROOT/infra/terraform/aws_benchmark"
+TFVARS="arcaneperhost.clusters_4.drivers_12.tfvars"
+REGION="us-east-1"
+SSM_WAIT_DEADLINE_SECS=600   # 10-minute ceiling; user-data installs Docker so first boot is slow
+
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --tfvars) TFVARS="$2"; shift 2 ;;
+        --region) REGION="$2"; shift 2 ;;
+        -h|--help)
+            sed -n '2,25p' "$0" | sed 's/^# //;s/^#//'
+            exit 0
+            ;;
+        *) echo "unknown arg: $1" >&2; exit 2 ;;
+    esac
+done
+
+TF_BIN="${TERRAFORM:-terraform}"
+if ! command -v "$TF_BIN" >/dev/null 2>&1; then
+    for cand in "$HOME/bin/terraform" "$HOME/.local/bin/terraform" "$HOME/.tfenv/bin/terraform"; do
+        if [[ -x "$cand" ]]; then TF_BIN="$cand"; break; fi
+    done
+fi
+command -v "$TF_BIN" >/dev/null 2>&1 || {
+    echo "setup.sh: terraform not found on PATH or in common install dirs." >&2
+    echo "  Install: https://developer.hashicorp.com/terraform/install" >&2
+    exit 2
+}
+
+if ! command -v aws >/dev/null 2>&1; then
+    echo "setup.sh: aws CLI not found on PATH. Install + configure credentials." >&2
+    exit 2
+fi
+if ! command -v jq >/dev/null 2>&1; then
+    echo "setup.sh: jq not found on PATH. Install: apt install jq / brew install jq" >&2
+    exit 2
+fi
+
+if [[ ! -f "$TF_DIR/$TFVARS" ]]; then
+    echo "setup.sh: tfvars file not found: $TF_DIR/$TFVARS" >&2
+    echo "  Available tfvars in this module:" >&2
+    ls "$TF_DIR"/*.tfvars 2>&1 | sed 's/^/    /' >&2
+    exit 2
+fi
+
+echo "==> setup.sh"
+echo "    terraform module: $TF_DIR"
+echo "    tfvars:           $TFVARS"
+echo "    region:           $REGION"
+
+# ── 1. terraform init (safe to re-run) ──────────────────────────────────────
+echo "==> terraform init"
+"$TF_BIN" -chdir="$TF_DIR" init -input=false -upgrade=false 1>/dev/null
+
+# ── 2. terraform apply ──────────────────────────────────────────────────────
+# operator_cidr_blocks defaults to [] in variables.tf so it's optional for
+# the README's PowerShell path. We pass 0.0.0.0/0 here so the new
+# controller-mode path (which opens orchestrator HTTP to the operator)
+# also works without the user knowing their public IP. Anyone running the
+# orchestrator-HTTP-public path in production should override this.
+echo "==> terraform apply"
+"$TF_BIN" -chdir="$TF_DIR" apply \
+    -var-file="$TFVARS" \
+    -var='operator_cidr_blocks=["0.0.0.0/0"]' \
+    -auto-approve
+
+# ── 3. Write canonical state JSON ───────────────────────────────────────────
+STATE_OUT_TF="$TF_DIR/.benchmark-aws-terraform.json"
+STATE_OUT_ROOT="$REPO_ROOT/.benchmark-aws-terraform.json"
+"$TF_BIN" -chdir="$TF_DIR" output -json benchmark_state > "$STATE_OUT_TF"
+# Mirror to the repo root too — the new bash launcher looks there. Keeping
+# both means README's PowerShell path (which reads from $TF_DIR) and the
+# new controller-mode path (which reads from the repo root) both work
+# without the user needing to copy the file around.
+cp "$STATE_OUT_TF" "$STATE_OUT_ROOT"
+echo "    state JSON written:"
+echo "      $STATE_OUT_TF"
+echo "      $STATE_OUT_ROOT"
+
+# ── 4. Wait for every EC2 to report SSM Online ──────────────────────────────
+# Replaces the README's "wait ~60 seconds" sleep. Reads the instance IDs
+# from the state JSON we just wrote, polls SSM until every one is Online,
+# bounded by SSM_WAIT_DEADLINE_SECS. This is the difference between "the
+# next step works" and "the next step fails confusingly with 'no SSM
+# associations found.'"
+mapfile -t INSTANCE_IDS < <(jq -r '
+    [.ManagerInstanceId, .RedisInstanceId, .SpacetimeInstanceId,
+     (.ClusterInstanceIds // [])[],
+     (.BenchmarkInstanceIds // [])[]] | .[] | select(. != null)
+' "$STATE_OUT_ROOT")
+EXPECTED=${#INSTANCE_IDS[@]}
+echo "==> waiting for SSM agents to come online on $EXPECTED instances"
+
+deadline=$(( $(date +%s) + SSM_WAIT_DEADLINE_SECS ))
+while (( $(date +%s) < deadline )); do
+    online=$(aws ssm describe-instance-information \
+        --region "$REGION" \
+        --filters "Key=InstanceIds,Values=$(IFS=,; echo "${INSTANCE_IDS[*]}")" \
+        --query 'length(InstanceInformationList)' \
+        --output text 2>/dev/null || echo 0)
+    echo "    ($online/$EXPECTED Online)"
+    if [[ "$online" == "$EXPECTED" ]]; then
+        break
+    fi
+    sleep 10
+done
+
+if [[ "${online:-0}" != "$EXPECTED" ]]; then
+    echo "setup.sh: SSM did not reach $EXPECTED Online within ${SSM_WAIT_DEADLINE_SECS}s." >&2
+    echo "  Got $online/$EXPECTED. Run scripts will fail." >&2
+    echo "  Re-run setup.sh — it's idempotent and will continue waiting." >&2
+    exit 1
+fi
+
+echo "==> READY: $EXPECTED instances Online. You can now run the benchmark."

--- a/plans/headline-13500.toml
+++ b/plans/headline-13500.toml
@@ -1,45 +1,91 @@
-# Headline benchmark: 13,500 CCU across 4 clusters.
-# Drives the orchestrator through warmup → ramp → steady-state.
+# Headline benchmark: matches the README's 13,500 CCU @ 60 Hz / 1 KB / 10.4 ms.
+#
+# target_players is AGGREGATE — the orchestrator distributes across active
+# drivers (e.g. 13,500 / 12 = 1,125 per driver, with remainder spread).
+#
+# Tier sequence mirrors the README: 1,500 → 13,500 aggregate in 1,500-step
+# increments, 30 s hold each, validity gate at 50 ms p99 latency (engine
+# gate; 100 ms production target leaves headroom for regional internet RTT).
 
 [plan]
 name = "headline-13500"
-description = "13,500 CCU headline benchmark across 4 clusters @ 30 Hz"
+description = "13,500 CCU @ 60 Hz / 1 KB user_data / 12 drivers — README headline"
 
-# ---------------------------------------------------------------------------
-# Phase 1: warmup. Bring the fleet to a small steady state to verify the
-# pipeline (drivers connecting, clusters polling). No strict latency gate
-# during warmup; the gate is just "we have entities."
-# ---------------------------------------------------------------------------
 [[phases]]
-name = "warmup"
-target_players = 1000
-spawn_delay_ms = 50
-hold_seconds = 60
-
+name = "tier-1500-aggregate"
+target_players = 1500
+spawn_delay_ms = 25
+hold_seconds = 30
 [phases.gate]
-min_entities = 800
+max_p99_latency_ms = 50
 
-# ---------------------------------------------------------------------------
-# Phase 2: ramp to headline. Spawn-delay is tightened so the join rate
-# doesn't dominate the ramp window. Steady-state hold at 13,500 CCU.
-# Latency gate enforced.
-# ---------------------------------------------------------------------------
 [[phases]]
-name = "ramp-to-13500"
+name = "tier-3000-aggregate"
+target_players = 3000
+spawn_delay_ms = 25
+hold_seconds = 30
+[phases.gate]
+max_p99_latency_ms = 50
+
+[[phases]]
+name = "tier-4500-aggregate"
+target_players = 4500
+spawn_delay_ms = 25
+hold_seconds = 30
+[phases.gate]
+max_p99_latency_ms = 50
+
+[[phases]]
+name = "tier-6000-aggregate"
+target_players = 6000
+spawn_delay_ms = 25
+hold_seconds = 30
+[phases.gate]
+max_p99_latency_ms = 50
+
+[[phases]]
+name = "tier-7500-aggregate"
+target_players = 7500
+spawn_delay_ms = 25
+hold_seconds = 30
+[phases.gate]
+max_p99_latency_ms = 50
+
+[[phases]]
+name = "tier-9000-aggregate"
+target_players = 9000
+spawn_delay_ms = 25
+hold_seconds = 30
+[phases.gate]
+max_p99_latency_ms = 50
+
+[[phases]]
+name = "tier-10500-aggregate"
+target_players = 10500
+spawn_delay_ms = 25
+hold_seconds = 30
+[phases.gate]
+max_p99_latency_ms = 50
+
+[[phases]]
+name = "tier-12000-aggregate"
+target_players = 12000
+spawn_delay_ms = 25
+hold_seconds = 30
+[phases.gate]
+max_p99_latency_ms = 50
+
+[[phases]]
+name = "tier-13500-aggregate-headline"
 target_players = 13500
 spawn_delay_ms = 25
-hold_seconds = 600
-
+hold_seconds = 30
 [phases.gate]
-max_p99_latency_ms = 100
-min_entities = 13000
+max_p99_latency_ms = 50
 
-# ---------------------------------------------------------------------------
-# Phase 3: cooldown. Soft tear-down so the orchestrator and clusters can
-# settle before terraform destroy. No gate.
-# ---------------------------------------------------------------------------
+# Cooldown: drain players cleanly so terraform destroy can complete fast.
 [[phases]]
 name = "cooldown"
 target_players = 0
 spawn_delay_ms = 25
-hold_seconds = 30
+hold_seconds = 10

--- a/plans/smoke-2cluster.toml
+++ b/plans/smoke-2cluster.toml
@@ -1,0 +1,17 @@
+[plan]
+name = "smoke-2cluster-aws"
+description = "AWS smoke against 2-cluster topology (1 driver). Validates the controller→orchestrator→driver wire works end-to-end on real EC2."
+
+[[phases]]
+name = "tiny-warmup"
+target_players = 50
+spawn_delay_ms = 20
+hold_seconds = 30
+
+[[phases]]
+name = "tiny-ramp"
+target_players = 100
+spawn_delay_ms = 10
+hold_seconds = 30
+[phases.gate]
+min_entities = 80


### PR DESCRIPTION
## Summary

- **`infra/aws/setup.sh` + `cleanup.sh`** — single-command wrappers replace the README's manual terraform invocations. Setup polls SSM until every EC2 is `Online` (no manual sleep). Cleanup runs `terraform destroy` then audits the AWS API directly, exiting non-zero with a leak list if anything's left.
- **Live ASCII dashboard** in the controller-mode binary (per-cluster entities + tick budget, driver fleet, recent commands with ack counts, phase + hold + gate + elapsed). Auto-detects TTY; `--dashboard auto|on|off` to override.
- **Two silent bugs fixed**: per-phase scheduler was emitting `Stop` between phases (drivers all died after tier 1); SSE consumer had a literal 0-second timeout that prevented any snapshot from being ingested (gate sat at default `Pass` for the whole run).
- README step 2 + step 4 updated to use the new wrappers; step 3 unchanged.

## Reproduction validated end-to-end

Cloned the working tree to a fresh tmp directory, followed the updated README verbatim:

| Step | Result |
|---|---|
| `./infra/aws/setup.sh` | terraform applied, 19 EC2s reached SSM Online in ~5 min |
| `pwsh ./infra/aws/Run-Benchmark-Aws.ps1 …` | 13,500-CCU ramp completed |
| `./infra/aws/cleanup.sh` | 36 resources destroyed, AWS audit `==> CLEAN` |

Top-tier numbers across 12 drivers at `players=1125`:
- **Mean latency: 8.50 – 8.75 ms** (better than the documented 10.39 ms headline)
- **0 errors** across ~24 M total round-trips
- All 12 drivers consistent (drift < 0.3 ms)

## What's deliberately out of scope (filed separately)

- [arcane#109](https://github.com/brainy-bots/arcane/issues/109) — fd-limit assertion at cluster startup. Library-side fix for the silent 1k-connection cap that bit us under Docker's default 1024 fd soft limit (worked around here via `--ulimit nofile=65536:65536` on every container).
- [arcane#110](https://github.com/brainy-bots/arcane/issues/110) — `ws_server` accept-loop resilience. Companion to #109.
- Dashboard state-machine extension (PROVISIONING → WAITING → RUNNING → DONE) covering the bash launcher's container-startup phase. Currently the dashboard only takes over once the controller binary starts; the ~30 s of container restart still scrolls plain text.

## Test plan

- [x] `cargo build -p benchmark-controller --release`
- [x] `cargo test -p benchmark-controller --release` (25 lib + 1 e2e)
- [x] `cleanup.sh` against an empty account exits 0 with `==> CLEAN`
- [x] `setup.sh` from a fresh-clone working tree provisions + waits for SSM Online
- [x] Headline reproduction (12 drivers / 4 clusters / 13,500 CCU) on real AWS — 0 errors, latency 8.5–8.75 ms mean
- [x] `cleanup.sh` after the run reports `==> CLEAN` with zero AWS-side leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)