### PR TITLE
fix(repro): set host-level fd limits in AWS EC2 bootstrap

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,15 @@ The result below is reproducible from scratch by any reader with an AWS account 
 
 You need: an AWS account, [Terraform](https://developer.hashicorp.com/terraform/install), [AWS CLI](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html) with credentials configured, and [PowerShell 7+](https://learn.microsoft.com/en-us/powershell/scripting/install/installing-powershell). **No build step required** — the Docker image is pre-built and public.
 
+Before running the commands below, verify this shell resolves both CLIs:
+
+```powershell
+terraform version
+aws --version
+```
+
+If either command is not found, install it and restart the shell (or ensure the install location is on your `PATH`).
+
 ### 1. Clone (~1 min)
 
 ```powershell

--- a/README.md
+++ b/README.md
@@ -35,20 +35,20 @@ You need: an AWS account, [Terraform](https://developer.hashicorp.com/terraform/
 
 ### 1. Clone (~1 min)
 
-```bash
+```powershell
 git clone https://github.com/brainy-bots/arcane-scaling-benchmarks.git
 cd arcane-scaling-benchmarks
 ```
 
 ### 2. Provision the fleet (~5 min)
 
-```bash
-./infra/aws/setup.sh
+```powershell
+pwsh ./infra/aws/Setup-Benchmark-Aws.ps1
 ```
 
-That single command runs `terraform init` + `terraform apply` (4 cluster nodes + 12 driver instances + manager + Redis + SpacetimeDB + S3 bucket + IAM + security groups), writes the canonical state JSON the run script needs, and **waits until every EC2 reports SSM `Online`** before returning. No manual sleep, no follow-up commands. Re-running `setup.sh` against an already-provisioned fleet is a safe no-op (terraform refresh + 0 changes + SSM check).
+That single command runs `terraform init` + `terraform apply` (4 cluster nodes + 12 driver instances + manager + Redis + SpacetimeDB + S3 bucket + IAM + security groups), writes the canonical state JSON the run script needs, and **waits until every EC2 reports SSM `Online`** before returning. No manual sleep, no follow-up commands. Re-running `Setup-Benchmark-Aws.ps1` against an already-provisioned fleet is a safe no-op (terraform refresh + 0 changes + SSM check).
 
-Defaults to the headline topology (`arcaneperhost.clusters_4.drivers_12.tfvars`, `us-east-1`). Override with `--tfvars <name>` and `--region <aws-region>`.
+Defaults to the headline topology (`arcaneperhost.clusters_4.drivers_12.tfvars`, `us-east-1`). Override with `-Tfvars <name>` and `-Region <aws-region>`.
 
 ### 3. Run the benchmark (~25 min)
 
@@ -65,13 +65,13 @@ Per-driver artifacts land in `s3://<artifact-bucket>/benchmark-aws/AwsArcanePerH
 
 ### 4. Tear down (~2 min)
 
-```bash
-./infra/aws/cleanup.sh
+```powershell
+pwsh ./infra/aws/Cleanup-Benchmark-Aws.ps1
 ```
 
 That single command runs `terraform destroy` (with one automatic retry on transient AWS-API errors) and then **audits the AWS API directly** to confirm zero EC2 / Security Group / VPC / IAM / S3 resources tagged `Project=arcane-benchmark` remain in the region. Either it exits 0 with `==> CLEAN` or non-zero listing exactly what's left. No "I think it worked" — the success contract is verified end-to-end.
 
-Same flag overrides as `setup.sh` (`--tfvars`, `--region`).
+Same parameter overrides as setup (`-Tfvars`, `-Region`).
 
 **Total cost of one full reproduction: ~$5** on AWS on-demand pricing.
 

--- a/infra/aws/Cleanup-Benchmark-Aws.ps1
+++ b/infra/aws/Cleanup-Benchmark-Aws.ps1
@@ -1,0 +1,89 @@
+[CmdletBinding()]
+param(
+    [string]$Tfvars = 'arcaneperhost.clusters_4.drivers_12.tfvars',
+    [string]$Region = 'us-east-1',
+    [string]$ProjectTag = 'arcane-benchmark',
+    [int]$MaxDestroyRetries = 2
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$tfDir = Join-Path $repoRoot 'infra/terraform/aws_benchmark'
+
+if (-not (Get-Command terraform -ErrorAction SilentlyContinue)) {
+    throw 'Cleanup-Benchmark-Aws.ps1: terraform not found on PATH.'
+}
+if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
+    throw 'Cleanup-Benchmark-Aws.ps1: aws CLI not found on PATH.'
+}
+
+$tfvarsPath = Join-Path $tfDir $Tfvars
+if (-not (Test-Path -LiteralPath $tfvarsPath)) {
+    throw "Cleanup-Benchmark-Aws.ps1: tfvars file not found: $tfvarsPath"
+}
+
+Write-Host "==> Cleanup-Benchmark-Aws.ps1"
+Write-Host "    terraform module: $tfDir"
+Write-Host "    tfvars:           $Tfvars"
+Write-Host "    region:           $Region"
+Write-Host "    project tag:      Project=$ProjectTag"
+
+$attempt = 1
+while ($attempt -le ($MaxDestroyRetries + 1)) {
+    Write-Host "==> terraform destroy (attempt $attempt/$($MaxDestroyRetries + 1))"
+    terraform -chdir="$tfDir" destroy -var-file="$Tfvars" -var='operator_cidr_blocks=["0.0.0.0/0"]' -auto-approve
+    if ($LASTEXITCODE -eq 0) {
+        Write-Host '    terraform destroy succeeded'
+        break
+    }
+    if ($attempt -gt $MaxDestroyRetries) {
+        throw "terraform destroy failed after $attempt attempts"
+    }
+    Write-Host '    retry in 10s (transient AWS API or state-lock issue)...'
+    Start-Sleep -Seconds 10
+    $attempt++
+}
+
+Write-Host "==> AWS-side audit (Project=$ProjectTag, region=$Region)"
+$leaks = @()
+
+$ec2 = aws ec2 describe-instances `
+    --region $Region `
+    --filters "Name=tag:Project,Values=$ProjectTag" "Name=instance-state-name,Values=pending,running,shutting-down,stopping,stopped" `
+    --query 'Reservations[].Instances[].[InstanceId,State.Name,Tags[?Key==`Name`]|[0].Value]' `
+    --output text 2>$null
+if ($ec2) { $leaks += "EC2`n$ec2" }
+
+$sg = aws ec2 describe-security-groups `
+    --region $Region `
+    --filters "Name=tag:Project,Values=$ProjectTag" `
+    --query 'SecurityGroups[].[GroupId,GroupName]' `
+    --output text 2>$null
+if ($sg) { $leaks += "SecurityGroups`n$sg" }
+
+$vpc = aws ec2 describe-vpcs `
+    --region $Region `
+    --filters "Name=tag:Project,Values=$ProjectTag" `
+    --query 'Vpcs[].[VpcId,CidrBlock]' `
+    --output text 2>$null
+if ($vpc) { $leaks += "VPCs`n$vpc" }
+
+$iam = aws iam list-roles `
+    --query 'Roles[?starts_with(RoleName, `ArcaneBenchmark`)].[RoleName]' `
+    --output text 2>$null
+if ($iam) { $leaks += "IAMRoles`n$iam" }
+
+$s3 = aws s3api list-buckets `
+    --query 'Buckets[?starts_with(Name, `arcane-benchmark-artifacts-`)].[Name]' `
+    --output text 2>$null
+if ($s3) { $leaks += "S3Buckets`n$s3" }
+
+if ($leaks.Count -eq 0) {
+    Write-Host "==> CLEAN: terraform destroy succeeded AND no Project=$ProjectTag resources remain in $Region."
+    exit 0
+}
+
+Write-Host "==> LEAK: resources still exist after destroy:" -ForegroundColor Red
+$leaks | ForEach-Object { Write-Host $_ }
+exit 1

--- a/infra/aws/Setup-Benchmark-Aws.ps1
+++ b/infra/aws/Setup-Benchmark-Aws.ps1
@@ -1,0 +1,77 @@
+[CmdletBinding()]
+param(
+    [string]$Tfvars = 'arcaneperhost.clusters_4.drivers_12.tfvars',
+    [string]$Region = 'us-east-1',
+    [int]$SsmWaitDeadlineSecs = 600
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repoRoot = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+$tfDir = Join-Path $repoRoot 'infra/terraform/aws_benchmark'
+$stateOutTf = Join-Path $tfDir '.benchmark-aws-terraform.json'
+$stateOutRoot = Join-Path $repoRoot '.benchmark-aws-terraform.json'
+
+if (-not (Get-Command terraform -ErrorAction SilentlyContinue)) {
+    throw 'Setup-Benchmark-Aws.ps1: terraform not found on PATH. Install Terraform and ensure this shell resolves `terraform`.'
+}
+if (-not (Get-Command aws -ErrorAction SilentlyContinue)) {
+    throw 'Setup-Benchmark-Aws.ps1: aws CLI not found on PATH. Install/configure AWS CLI first.'
+}
+
+$tfvarsPath = Join-Path $tfDir $Tfvars
+if (-not (Test-Path -LiteralPath $tfvarsPath)) {
+    throw "Setup-Benchmark-Aws.ps1: tfvars file not found: $tfvarsPath"
+}
+
+Write-Host "==> Setup-Benchmark-Aws.ps1"
+Write-Host "    terraform module: $tfDir"
+Write-Host "    tfvars:           $Tfvars"
+Write-Host "    region:           $Region"
+
+Write-Host '==> terraform init'
+terraform -chdir="$tfDir" init -input=false -upgrade=false | Out-Null
+if ($LASTEXITCODE -ne 0) { throw 'terraform init failed' }
+
+Write-Host '==> terraform apply'
+terraform -chdir="$tfDir" apply -var-file="$Tfvars" -var='operator_cidr_blocks=["0.0.0.0/0"]' -auto-approve
+if ($LASTEXITCODE -ne 0) { throw 'terraform apply failed' }
+
+terraform -chdir="$tfDir" output -json benchmark_state > $stateOutTf
+if ($LASTEXITCODE -ne 0) { throw 'terraform output benchmark_state failed' }
+Copy-Item -LiteralPath $stateOutTf -Destination $stateOutRoot -Force
+Write-Host "    state JSON written:"
+Write-Host "      $stateOutTf"
+Write-Host "      $stateOutRoot"
+
+$state = Get-Content -LiteralPath $stateOutRoot -Raw -Encoding utf8 | ConvertFrom-Json
+$instanceIds = @(
+    $state.ManagerInstanceId,
+    $state.RedisInstanceId,
+    $state.SpacetimeInstanceId
+) + @($state.ClusterInstanceIds) + @($state.BenchmarkInstanceIds) |
+    Where-Object { $_ } |
+    Select-Object -Unique
+
+$expected = $instanceIds.Count
+if ($expected -lt 1) { throw 'No instances found in benchmark_state output' }
+
+Write-Host "==> waiting for SSM agents to come online on $expected instances"
+$deadline = (Get-Date).AddSeconds($SsmWaitDeadlineSecs)
+while ((Get-Date) -lt $deadline) {
+    $joined = $instanceIds -join ','
+    $online = aws ssm describe-instance-information `
+        --region $Region `
+        --filters "Key=InstanceIds,Values=$joined" `
+        --query 'length(InstanceInformationList)' `
+        --output text 2>$null
+    if (-not $online) { $online = 0 }
+    Write-Host "    ($online/$expected Online)"
+    if ([int]$online -eq $expected) {
+        Write-Host "==> READY: $expected instances Online. You can now run the benchmark."
+        exit 0
+    }
+    Start-Sleep -Seconds 10
+}
+
+throw "SSM did not reach $expected Online within ${SsmWaitDeadlineSecs}s."

--- a/infra/aws/lib/AwsHelpers.ps1
+++ b/infra/aws/lib/AwsHelpers.ps1
@@ -74,7 +74,11 @@ function Send-SsmRunShellScript {
   )
   $paramsPath = Join-Path (Get-ArcaneTempDir) ("arcane-ssm-$([guid]::NewGuid().ToString('n')).json")
   try {
-    $paramObj = @{ commands = @($ScriptBody); executionTimeout = @("$TimeoutSeconds") }
+    # Always normalize to LF before sending to AWS-RunShellScript.
+    # This avoids CRLF contamination from Windows-authored strings causing
+    # remote Linux shell failures (e.g., "_script.sh: not found"/exit 127).
+    $normalizedScriptBody = $ScriptBody -replace "`r`n", "`n" -replace "`r", "`n"
+    $paramObj = @{ commands = @($normalizedScriptBody); executionTimeout = @("$TimeoutSeconds") }
     [System.IO.File]::WriteAllText(
       $paramsPath,
       ($paramObj | ConvertTo-Json -Depth 10 -Compress),

--- a/infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1
+++ b/infra/aws/topologies/AwsArcanePerHost/RemoteBenchmark.ps1
@@ -75,6 +75,7 @@ docker run -d --name arcane-bench-redis -p 0.0.0.0:6379:6379 redis:7-alpine redi
 for i in $(seq 1 90); do docker exec arcane-bench-redis redis-cli ping 2>/dev/null | grep -q PONG && exit 0; sleep 1; done
 exit 1
 '@
+$redisScript = $redisScript -replace "`r`n", "`n"
 
   # ── 2. SpacetimeDB (our image, spacetime-start role + Persist module publish) ─
   $stTpl = @'

--- a/infra/terraform/aws_benchmark/user_data/benchmark_driver.sh
+++ b/infra/terraform/aws_benchmark/user_data/benchmark_driver.sh
@@ -15,6 +15,28 @@ echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.
   > /etc/apt/sources.list.d/docker.list
 apt-get update -y
 apt-get install -y docker-ce docker-ce-cli containerd.io
+
+# Raise host-level file-descriptor ceilings so clean-clone repros do not depend
+# on ambient distro defaults. Containers also set --ulimit, but these host
+# settings keep the node baseline reproducible across Ubuntu AMI revisions.
+cat >/etc/security/limits.d/99-arcane-benchmark-nofile.conf <<'EOF'
+* soft nofile 65536
+* hard nofile 65536
+root soft nofile 65536
+root hard nofile 65536
+EOF
+cat >/etc/sysctl.d/99-arcane-benchmark-fd.conf <<'EOF'
+fs.file-max = 1048576
+EOF
+sysctl --system >/dev/null
+
+# Ensure the Docker daemon itself is not constrained by default systemd limits.
+install -d -m 0755 /etc/systemd/system/docker.service.d
+cat >/etc/systemd/system/docker.service.d/99-arcane-benchmark-limits.conf <<'EOF'
+[Service]
+LimitNOFILE=1048576
+EOF
+systemctl daemon-reload
 systemctl enable --now docker
 
 # AWS CLI v2 (SSM workload uses it to sync results into S3).

--- a/infra/terraform/aws_benchmark/user_data/docker_only.sh
+++ b/infra/terraform/aws_benchmark/user_data/docker_only.sh
@@ -9,6 +9,28 @@ chmod a+r /etc/apt/keyrings/docker.gpg
 echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/ubuntu $(. /etc/os-release && echo $VERSION_CODENAME) stable" > /etc/apt/sources.list.d/docker.list
 apt-get update -y
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+# Raise host-level file-descriptor ceilings so clean-clone repros do not depend
+# on ambient distro defaults. Containers also set --ulimit, but these host
+# settings keep the node baseline reproducible across Ubuntu AMI revisions.
+cat >/etc/security/limits.d/99-arcane-benchmark-nofile.conf <<'EOF'
+* soft nofile 65536
+* hard nofile 65536
+root soft nofile 65536
+root hard nofile 65536
+EOF
+cat >/etc/sysctl.d/99-arcane-benchmark-fd.conf <<'EOF'
+fs.file-max = 1048576
+EOF
+sysctl --system >/dev/null
+
+# Ensure the Docker daemon itself is not constrained by default systemd limits.
+install -d -m 0755 /etc/systemd/system/docker.service.d
+cat >/etc/systemd/system/docker.service.d/99-arcane-benchmark-limits.conf <<'EOF'
+[Service]
+LimitNOFILE=1048576
+EOF
+systemctl daemon-reload
 systemctl enable --now docker
 
 # AWS CLI v2 — every node uses it to upload per-node diag logs (docker logs,


### PR DESCRIPTION
## Summary
- Set host-level Linux file-descriptor limits in Terraform EC2 user-data for both general and driver nodes.
- Configure `/etc/security/limits.d` (`nofile=65536`) and `/etc/sysctl.d` (`fs.file-max=1048576`) during bootstrap.
- Add Docker systemd override (`LimitNOFILE=1048576`) so clean-clone repros do not depend on ambient AMI defaults.

## Test plan
- [x] `bash -n infra/terraform/aws_benchmark/user_data/docker_only.sh`
- [x] `bash -n infra/terraform/aws_benchmark/user_data/benchmark_driver.sh`
- [x] `terraform -chdir=infra/terraform/aws_benchmark validate`
