### PR TITLE
feat: publish benchmark images with proper versioned tags

### DIFF
--- a/.github/workflows/docker-publish-operator.yml
+++ b/.github/workflows/docker-publish-operator.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: docker/operator.Dockerfile
+          file: ./docker/operator.Dockerfile
           push: true
           platforms: linux/amd64
           tags: |

--- a/.github/workflows/docker-publish-operator.yml
+++ b/.github/workflows/docker-publish-operator.yml
@@ -1,0 +1,68 @@
+name: Publish operator Docker image
+
+# Builds and pushes the operator image to GHCR. This is the "one-click
+# reproducibility" container: it bundles pwsh, Terraform, AWS CLI, and the
+# benchmark-controller binary so anyone can reproduce results without
+# installing tooling locally.
+#
+# Triggers:
+#   - tag push matching v*           → pushes :latest + :<tag>
+#   - manual (workflow_dispatch)     → pushes a dev tag for testing
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Image tag to push (e.g. operator-dev-20260510)"
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout (with submodules)
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Resolve image tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "tag=${GITHUB_REF#refs/tags/}" >> "$GITHUB_OUTPUT"
+            echo "also_latest=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
+            echo "also_latest=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docker/operator.Dockerfile
+          push: true
+          platforms: linux/amd64
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/arcane-benchmark-operator:${{ steps.tag.outputs.tag }}
+            ${{ steps.tag.outputs.also_latest == 'true' && format('ghcr.io/{0}/arcane-benchmark-operator:latest', github.repository_owner) || '' }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/.github/workflows/docker-publish-operator.yml
+++ b/.github/workflows/docker-publish-operator.yml
@@ -58,7 +58,7 @@ jobs:
         uses: docker/build-push-action@v6
         with:
           context: .
-          file: ./docker/operator.Dockerfile
+          file: Dockerfile.operator
           push: true
           platforms: linux/amd64
           tags: |

--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -1,0 +1,48 @@
+FROM rust:1.95-bookworm AS controller-builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      pkg-config libssl-dev ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+
+# Build benchmark-controller with its path dependency on arcane-swarm-orchestrator.
+COPY crates/benchmark-controller/ crates/benchmark-controller/
+COPY arcane_swarm/crates/arcane-swarm-orchestrator/ arcane_swarm/crates/arcane-swarm-orchestrator/
+
+RUN cargo build --release --manifest-path crates/benchmark-controller/Cargo.toml
+
+FROM mcr.microsoft.com/powershell:7.4-debian-12
+
+ARG TERRAFORM_VERSION=1.9.8
+ARG AWSCLI_VERSION=2.17.53
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      ca-certificates curl unzip jq \
+    && rm -rf /var/lib/apt/lists/*
+
+# Terraform
+RUN curl -fsSLo /tmp/terraform.zip "https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip" \
+    && unzip /tmp/terraform.zip -d /usr/local/bin \
+    && rm -f /tmp/terraform.zip
+
+# AWS CLI v2
+RUN curl -fsSLo /tmp/awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64-${AWSCLI_VERSION}.zip" \
+    && unzip -q /tmp/awscliv2.zip -d /tmp \
+    && /tmp/aws/install --bin-dir /usr/local/bin --install-dir /usr/local/aws-cli --update \
+    && rm -rf /tmp/aws /tmp/awscliv2.zip
+
+WORKDIR /workspace
+
+# Copy only what the operator path needs.
+COPY infra/ infra/
+COPY plans/ plans/
+COPY docker/benchmark-publish-module.sh docker/benchmark-publish-module.sh
+
+# Place the controller binary where Run-Benchmark-Aws-Controller.ps1 auto-discovers it.
+COPY --from=controller-builder /src/crates/benchmark-controller/target/release/benchmark-controller /workspace/crates/benchmark-controller/target/release/benchmark-controller
+
+COPY docker/operator-entrypoint.sh /usr/local/bin/operator-entrypoint.sh
+RUN chmod +x /usr/local/bin/operator-entrypoint.sh /workspace/docker/benchmark-publish-module.sh
+
+ENTRYPOINT ["/usr/local/bin/operator-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ docker run --rm -it `
 If GHCR access is unavailable, build and use the local fallback image:
 
 ```powershell
-docker build -f docker/operator.Dockerfile -t arcane-benchmark-operator:test .
+docker build -f Dockerfile.operator -t arcane-benchmark-operator:test .
 
 docker run --rm -it `
   -e AWS_PROFILE=default `

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run --rm -it `
   -e AWS_REGION=us-east-1 `
   -v "${env:USERPROFILE}\.aws:/root/.aws:ro" `
   -v "${PWD}\results:/workspace/results" `
-  ghcr.io/brainy-bots/arcane-benchmark-operator:<operator-tag>
+  ghcr.io/brainy-bots/arcane-benchmark-operator:latest
 ```
 
 If GHCR access is unavailable, build and use the local fallback image:

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run --rm -it `
   -e AWS_REGION=us-east-1 `
   -v "${env:USERPROFILE}\.aws:/root/.aws:ro" `
   -v "${PWD}\results:/workspace/results" `
-  ghcr.io/brainy-bots/arcane-benchmark-operator:latest
+  ghcr.io/brainy-bots/arcane-benchmark-operator:v0.2.0
 ```
 
 If GHCR access is unavailable, build and use the local fallback image:
@@ -142,7 +142,7 @@ Run from an **interactive terminal window** (dashboard rendering assumes stdout 
 First, pick an image tag that actually exists on GHCR (do not assume `latest` exists):
 
 ```powershell
-$BenchmarkImage = 'ghcr.io/brainy-bots/arcane-benchmark:dev-20260503-025321-diag'
+$BenchmarkImage = 'ghcr.io/brainy-bots/arcane-benchmark:v0.2.0'
 docker manifest inspect $BenchmarkImage | Out-Null
 ```
 

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -171,7 +171,7 @@ Optional flow (three phases, split by tool so every AWS resource is declarative)
    ```bash
    terraform output -json benchmark_state > .benchmark-aws-terraform.json
    ```
-2. **Run** — **`infra/aws/Run-Benchmark-Aws.ps1 -StatePath .benchmark-aws-terraform.json -ConfigFile <...> -BenchmarkImage ghcr.io/<org>/arcane-benchmark:<tag>`** invokes SSM on every node to `docker pull` the pre-built benchmark image and `docker run` the role container (`spacetime start`, `arcane-manager`, `benchmark-cluster`, `run-benchmark`). Nothing is compiled on EC2. Results are uploaded to S3; **`infra/aws/Collect-AwsBenchmarkResults.ps1`** / **`Sync-AwsBenchmarkResultsFromS3.ps1`** pull them into **`results/runs/<Environment>/<runId>/`** locally.
+2. **Run** — **`infra/aws/Run-Benchmark-Aws.ps1 -StatePath .benchmark-aws-terraform.json -ConfigFile <...> -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:dev-20260503-025321-diag`** invokes SSM on every node to `docker pull` the pre-built benchmark image and `docker run` the role container (`spacetime start`, `arcane-manager`, `benchmark-cluster`, `run-benchmark`). Nothing is compiled on EC2. Results are uploaded to S3; **`infra/aws/Collect-AwsBenchmarkResults.ps1`** / **`Sync-AwsBenchmarkResultsFromS3.ps1`** pull them into **`results/runs/<Environment>/<runId>/`** locally.
 3. **Tear down** — `terraform destroy` removes every resource. No alternate cleanup path exists; this keeps reproduction deterministic for anyone starting from an empty AWS account.
 
 See **`infra/terraform/aws_benchmark/README.md`** for the module details.

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -171,7 +171,7 @@ Optional flow (three phases, split by tool so every AWS resource is declarative)
    ```bash
    terraform output -json benchmark_state > .benchmark-aws-terraform.json
    ```
-2. **Run** — **`infra/aws/Run-Benchmark-Aws.ps1 -StatePath .benchmark-aws-terraform.json -ConfigFile <...> -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:dev-20260503-025321-diag`** invokes SSM on every node to `docker pull` the pre-built benchmark image and `docker run` the role container (`spacetime start`, `arcane-manager`, `benchmark-cluster`, `run-benchmark`). Nothing is compiled on EC2. Results are uploaded to S3; **`infra/aws/Collect-AwsBenchmarkResults.ps1`** / **`Sync-AwsBenchmarkResultsFromS3.ps1`** pull them into **`results/runs/<Environment>/<runId>/`** locally.
+2. **Run** — **`infra/aws/Run-Benchmark-Aws.ps1 -StatePath .benchmark-aws-terraform.json -ConfigFile <...> -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:v0.2.0`** invokes SSM on every node to `docker pull` the pre-built benchmark image and `docker run` the role container (`spacetime start`, `arcane-manager`, `benchmark-cluster`, `run-benchmark`). Nothing is compiled on EC2. Results are uploaded to S3; **`infra/aws/Collect-AwsBenchmarkResults.ps1`** / **`Sync-AwsBenchmarkResultsFromS3.ps1`** pull them into **`results/runs/<Environment>/<runId>/`** locally.
 3. **Tear down** — `terraform destroy` removes every resource. No alternate cleanup path exists; this keeps reproduction deterministic for anyone starting from an empty AWS account.
 
 See **`infra/terraform/aws_benchmark/README.md`** for the module details.

--- a/docker/operator-entrypoint.sh
+++ b/docker/operator-entrypoint.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd /workspace
+
+# Defaults mirror the documented headline run.
+# Default matches README / manual runs (override with -e BENCHMARK_IMAGE=...).
+BENCHMARK_IMAGE="${BENCHMARK_IMAGE:-ghcr.io/brainy-bots/arcane-benchmark:v0.2.0}"
+PLAN_FILE="${PLAN_FILE:-./plans/headline-13500.toml}"
+TFVARS_FILE="${TFVARS_FILE:-arcaneperhost.clusters_4.drivers_12.tfvars}"
+AWS_REGION_VALUE="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"
+
+if [ "$#" -gt 0 ] && [ "${1#-}" != "$1" ]; then
+  exec pwsh -NoProfile ./infra/aws/Run-Repro-Aws-Controller.ps1 \
+    -PlanFile "$PLAN_FILE" \
+    -BenchmarkImage "$BENCHMARK_IMAGE" \
+    -Tfvars "$TFVARS_FILE" \
+    -Region "$AWS_REGION_VALUE" \
+    "$@"
+elif [ "$#" -eq 0 ]; then
+  exec pwsh -NoProfile ./infra/aws/Run-Repro-Aws-Controller.ps1 \
+    -PlanFile "$PLAN_FILE" \
+    -BenchmarkImage "$BENCHMARK_IMAGE" \
+    -Tfvars "$TFVARS_FILE" \
+    -Region "$AWS_REGION_VALUE"
+else
+  exec "$@"
+fi

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -51,7 +51,7 @@ terraform -chdir=infra/terraform/aws_benchmark output -json benchmark_state |
 pwsh ./infra/aws/Run-Benchmark-Aws.ps1 `
   -StatePath .\.benchmark-aws-terraform.json `
   -ConfigFile .\configs\<your-config>.json `
-  -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:v0.1.0
+  -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:dev-20260503-025321-diag
 
 # 5. Collect results (optional; Run-Benchmark-Aws.ps1 syncs by default)
 pwsh ./infra/aws/Collect-AwsBenchmarkResults.ps1
@@ -68,7 +68,7 @@ terraform destroy
 - **Terraform** — needed for the provision and destroy steps. See [module install instructions](../terraform/aws_benchmark/README.md#install-terraform) (Windows / macOS / Linux).
 - **AWS CLI** configured so `aws sts get-caller-identity` succeeds.
 - Your identity needs `s3:GetObject` (and usually `s3:ListBucket`) on the artifact bucket to download results unless you use `-SkipLocalResultsDownload`.
-- A **pre-built benchmark image** on a public registry. The CI workflow `docker-publish.yml` builds `ghcr.io/<org>/arcane-benchmark:<tag>` on every `v*` tag. Pass the full reference via `-BenchmarkImage` (or set `ARCANE_BENCHMARK_IMAGE`). Nothing is compiled on EC2.
+- A **pre-built benchmark image** on a public registry. The current published image is `ghcr.io/brainy-bots/arcane-benchmark:dev-20260503-025321-diag`. Pass the full reference via `-BenchmarkImage` (or set `ARCANE_BENCHMARK_IMAGE`). Nothing is compiled on EC2.
 
 ## Adding a topology
 

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -51,7 +51,7 @@ terraform -chdir=infra/terraform/aws_benchmark output -json benchmark_state |
 pwsh ./infra/aws/Run-Benchmark-Aws.ps1 `
   -StatePath .\.benchmark-aws-terraform.json `
   -ConfigFile .\configs\<your-config>.json `
-  -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:dev-20260503-025321-diag
+  -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:v0.2.0
 
 # 5. Collect results (optional; Run-Benchmark-Aws.ps1 syncs by default)
 pwsh ./infra/aws/Collect-AwsBenchmarkResults.ps1
@@ -68,7 +68,7 @@ terraform destroy
 - **Terraform** — needed for the provision and destroy steps. See [module install instructions](../terraform/aws_benchmark/README.md#install-terraform) (Windows / macOS / Linux).
 - **AWS CLI** configured so `aws sts get-caller-identity` succeeds.
 - Your identity needs `s3:GetObject` (and usually `s3:ListBucket`) on the artifact bucket to download results unless you use `-SkipLocalResultsDownload`.
-- A **pre-built benchmark image** on a public registry. The current published image is `ghcr.io/brainy-bots/arcane-benchmark:dev-20260503-025321-diag`. Pass the full reference via `-BenchmarkImage` (or set `ARCANE_BENCHMARK_IMAGE`). Nothing is compiled on EC2.
+- A **pre-built benchmark image** on a public registry. The current published image is `ghcr.io/brainy-bots/arcane-benchmark:v0.2.0`. Pass the full reference via `-BenchmarkImage` (or set `ARCANE_BENCHMARK_IMAGE`). Nothing is compiled on EC2.
 
 ## Adding a topology
 


### PR DESCRIPTION
## Summary

- Add `docker-publish-operator.yml` workflow to publish the operator image (`ghcr.io/brainy-bots/arcane-benchmark-operator`) on tag push and manual dispatch
- Replace all placeholder image refs (`<org>`, `<tag>`, `<operator-tag>`, `dev-YYYYMMDD-HHMMSS-diag`) with exact versioned tags (`v0.2.0`) across README.md, REPRODUCIBILITY.md, and infra/aws/README.md
- Pin operator entrypoint default to `v0.2.0`

Anyone reproducing the benchmark can now copy-paste the Docker commands directly — no guessing which image/tag to use.

## Test plan

- [ ] Verify `ghcr.io/brainy-bots/arcane-benchmark:v0.2.0` is pullable after the tag-triggered workflow completes
- [ ] Verify `ghcr.io/brainy-bots/arcane-benchmark-operator:v0.2.0` builds successfully
- [ ] Run a benchmark using the operator image to confirm end-to-end flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)