### PR TITLE
fix: operator image CRLF + bump to v0.3.0

### DIFF
--- a/Dockerfile.operator
+++ b/Dockerfile.operator
@@ -43,6 +43,7 @@ COPY docker/benchmark-publish-module.sh docker/benchmark-publish-module.sh
 COPY --from=controller-builder /src/crates/benchmark-controller/target/release/benchmark-controller /workspace/crates/benchmark-controller/target/release/benchmark-controller
 
 COPY docker/operator-entrypoint.sh /usr/local/bin/operator-entrypoint.sh
-RUN chmod +x /usr/local/bin/operator-entrypoint.sh /workspace/docker/benchmark-publish-module.sh
+RUN sed -i 's/\r$//' /usr/local/bin/operator-entrypoint.sh /workspace/docker/benchmark-publish-module.sh \
+    && chmod +x /usr/local/bin/operator-entrypoint.sh /workspace/docker/benchmark-publish-module.sh
 
 ENTRYPOINT ["/usr/local/bin/operator-entrypoint.sh"]

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ docker run --rm -it `
   -e AWS_REGION=us-east-1 `
   -v "${env:USERPROFILE}\.aws:/root/.aws:ro" `
   -v "${PWD}\results:/workspace/results" `
-  ghcr.io/brainy-bots/arcane-benchmark-operator:v0.2.0
+  ghcr.io/brainy-bots/arcane-benchmark-operator:v0.3.0
 ```
 
 If GHCR access is unavailable, build and use the local fallback image:
@@ -142,7 +142,7 @@ Run from an **interactive terminal window** (dashboard rendering assumes stdout 
 First, pick an image tag that actually exists on GHCR (do not assume `latest` exists):
 
 ```powershell
-$BenchmarkImage = 'ghcr.io/brainy-bots/arcane-benchmark:v0.2.0'
+$BenchmarkImage = 'ghcr.io/brainy-bots/arcane-benchmark:v0.3.0'
 docker manifest inspect $BenchmarkImage | Out-Null
 ```
 

--- a/REPRODUCIBILITY.md
+++ b/REPRODUCIBILITY.md
@@ -171,7 +171,7 @@ Optional flow (three phases, split by tool so every AWS resource is declarative)
    ```bash
    terraform output -json benchmark_state > .benchmark-aws-terraform.json
    ```
-2. **Run** — **`infra/aws/Run-Benchmark-Aws.ps1 -StatePath .benchmark-aws-terraform.json -ConfigFile <...> -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:v0.2.0`** invokes SSM on every node to `docker pull` the pre-built benchmark image and `docker run` the role container (`spacetime start`, `arcane-manager`, `benchmark-cluster`, `run-benchmark`). Nothing is compiled on EC2. Results are uploaded to S3; **`infra/aws/Collect-AwsBenchmarkResults.ps1`** / **`Sync-AwsBenchmarkResultsFromS3.ps1`** pull them into **`results/runs/<Environment>/<runId>/`** locally.
+2. **Run** — **`infra/aws/Run-Benchmark-Aws.ps1 -StatePath .benchmark-aws-terraform.json -ConfigFile <...> -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:v0.3.0`** invokes SSM on every node to `docker pull` the pre-built benchmark image and `docker run` the role container (`spacetime start`, `arcane-manager`, `benchmark-cluster`, `run-benchmark`). Nothing is compiled on EC2. Results are uploaded to S3; **`infra/aws/Collect-AwsBenchmarkResults.ps1`** / **`Sync-AwsBenchmarkResultsFromS3.ps1`** pull them into **`results/runs/<Environment>/<runId>/`** locally.
 3. **Tear down** — `terraform destroy` removes every resource. No alternate cleanup path exists; this keeps reproduction deterministic for anyone starting from an empty AWS account.
 
 See **`infra/terraform/aws_benchmark/README.md`** for the module details.

--- a/docker/operator-entrypoint.sh
+++ b/docker/operator-entrypoint.sh
@@ -5,7 +5,7 @@ cd /workspace
 
 # Defaults mirror the documented headline run.
 # Default matches README / manual runs (override with -e BENCHMARK_IMAGE=...).
-BENCHMARK_IMAGE="${BENCHMARK_IMAGE:-ghcr.io/brainy-bots/arcane-benchmark:v0.2.0}"
+BENCHMARK_IMAGE="${BENCHMARK_IMAGE:-ghcr.io/brainy-bots/arcane-benchmark:v0.3.0}"
 PLAN_FILE="${PLAN_FILE:-./plans/headline-13500.toml}"
 TFVARS_FILE="${TFVARS_FILE:-arcaneperhost.clusters_4.drivers_12.tfvars}"
 AWS_REGION_VALUE="${AWS_REGION:-${AWS_DEFAULT_REGION:-us-east-1}}"

--- a/infra/aws/README.md
+++ b/infra/aws/README.md
@@ -51,7 +51,7 @@ terraform -chdir=infra/terraform/aws_benchmark output -json benchmark_state |
 pwsh ./infra/aws/Run-Benchmark-Aws.ps1 `
   -StatePath .\.benchmark-aws-terraform.json `
   -ConfigFile .\configs\<your-config>.json `
-  -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:v0.2.0
+  -BenchmarkImage ghcr.io/brainy-bots/arcane-benchmark:v0.3.0
 
 # 5. Collect results (optional; Run-Benchmark-Aws.ps1 syncs by default)
 pwsh ./infra/aws/Collect-AwsBenchmarkResults.ps1
@@ -68,7 +68,7 @@ terraform destroy
 - **Terraform** — needed for the provision and destroy steps. See [module install instructions](../terraform/aws_benchmark/README.md#install-terraform) (Windows / macOS / Linux).
 - **AWS CLI** configured so `aws sts get-caller-identity` succeeds.
 - Your identity needs `s3:GetObject` (and usually `s3:ListBucket`) on the artifact bucket to download results unless you use `-SkipLocalResultsDownload`.
-- A **pre-built benchmark image** on a public registry. The current published image is `ghcr.io/brainy-bots/arcane-benchmark:v0.2.0`. Pass the full reference via `-BenchmarkImage` (or set `ARCANE_BENCHMARK_IMAGE`). Nothing is compiled on EC2.
+- A **pre-built benchmark image** on a public registry. The current published image is `ghcr.io/brainy-bots/arcane-benchmark:v0.3.0`. Pass the full reference via `-BenchmarkImage` (or set `ARCANE_BENCHMARK_IMAGE`). Nothing is compiled on EC2.
 
 ## Adding a topology
 


### PR DESCRIPTION
## Summary

- Fix CRLF line endings in operator Dockerfile (entrypoint was failing with `bash\r: No such file or directory`)
- Bump all image tag references from `v0.2.0` → `v0.3.0` (the `v0.2.0` image was built from a commit that predates `Run-Repro-Aws-Controller.ps1`)

After merge, tag `v0.3.0` to trigger both image publishes, then verify with:
```
docker run --rm ghcr.io/brainy-bots/arcane-benchmark-operator:v0.3.0
```

## Test plan

- [ ] Merge and tag `v0.3.0`
- [ ] Verify operator image entrypoint starts (no CRLF error)
- [ ] Run smoke benchmark via operator image
- [ ] Verify benchmark image is pullable at `v0.3.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)